### PR TITLE
Add support for allocate and best effort cycle per priority group

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -123,8 +123,9 @@ type OptimizerData struct {
 
 // Specifications for optimizer data
 type OptimizerSpec struct {
-	Unlimited        bool   `json:"unlimited"`        // unlimited number of accelerator types (for capacity planning and/or cloud)
-	SaturationPolicy string `json:"saturationPolicy"` // allocation policy under saturated condition
+	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
+	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
+	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
 }
 
 type AllocationSolution struct {

--- a/rest-server/README.md
+++ b/rest-server/README.md
@@ -216,7 +216,8 @@ The following data is needed by the Optimizer (Declarations described [types](..
     ```json
     {
         "optimizer": {
-            "unlimited": true,
+            "unlimited": false,
+            "delayedBestEffort": false,
             "saturationPolicy" : "None"
         }
     }
@@ -225,6 +226,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
     The flags are as follows.
 
     - `unlimited`: The available number of accelerator types is unlimited (used in capacity planning mode), as opposed to being limited to the specified number (used in cluster mode).
+    - `delayedBestEffort`: Delay best effort allocation after attempting allocation to all priority groups.
     - `saturationPolicy`: Set an allocation policy under saturated condition.
 
       - ***None***: no additional allocation beyond satisfying SLOs


### PR DESCRIPTION
**BEFORE**

The greedy algorithm works in two phases, in series:

- Satisfy SLOs (_Allocate_): Go through servers in priority order and allocate GPUs to servers so as to satisfy their SLOs. If cannot satisfy SLOs for a server (not enough GPUs), that server is skipped and processed in phase 2. Subsequent servers in the ordered list continue to be processed.
- Apply saturation policy (_Best Effort_): For the servers that got no allocation in phase 1, order and process them according to the saturation policy. None, some, or all servers will get GPUs, but not enough to satisfy their SLOs.

Accordingly, it may very well happen, that a low priority server get allocated GPUs and have its SLOs satisfied, whereas a high priority server may get no allocation or an allocation that does not meet its SLOs.

**AFTER**

Added option `DelayedBestEffort`, with value `true` resulting in old behavior, and value `false` in new (default) behavior.

```
// Specifications for optimizer data
type OptimizerSpec struct {
	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
}
```

New procedure:
- group servers with same priority, and
- for each group, in order, execute the two phases, before moving on to the next group.

