### PR TITLE
Add prefill specs

### DIFF
--- a/demos/scale/main.go
+++ b/demos/scale/main.go
@@ -121,12 +121,12 @@ func main() {
 	}
 	fmt.Println("AllocBefore: ", allocBefore)
 	newArv := load.ArrivalRate * 2.5
-	newLength := int(float32(load.AvgLength) * 1.5)
+	newOutTokens := int(float32(load.AvgOutTokens) * 1.5)
+	newInTokens := int(float32(load.AvgInTokens) * 1.5)
 	newLoad := config.ServerLoadSpec{
-		ArrivalRate: newArv,
-		AvgLength:   newLength,
-		ArrivalCOV:  load.ArrivalCOV,
-		ServiceCOV:  load.ServiceCOV,
+		ArrivalRate:  newArv,
+		AvgInTokens:  newInTokens,
+		AvgOutTokens: newOutTokens,
 	}
 	server.SetLoad(&newLoad)
 

--- a/demos/transition/main.go
+++ b/demos/transition/main.go
@@ -122,23 +122,26 @@ func main() {
 		}
 
 		factorB := 2 * (rand.Float32() - 0.5) * (1 - alpha)
-		newLength := int(math.Ceil(float64(float32(load.AvgLength) * (1 + factorB))))
-		if newLength <= 0 {
-			newLength = 1
+		newInTokens := int(math.Ceil(float64(float32(load.AvgInTokens) * (1 + factorB))))
+		newOutTokens := int(math.Ceil(float64(float32(load.AvgOutTokens) * (1 + factorB))))
+		if newInTokens <= 0 {
+			newInTokens = 1
+		}
+		if newOutTokens <= 0 {
+			newOutTokens = 1
 		}
 		newLoad := config.ServerLoadSpec{
-			ArrivalRate: newArv,
-			AvgLength:   newLength,
-			ArrivalCOV:  load.ArrivalCOV,
-			ServiceCOV:  load.ServiceCOV,
+			ArrivalRate:  newArv,
+			AvgInTokens:  newInTokens,
+			AvgOutTokens: newOutTokens,
 		}
 		server.SetLoad(&newLoad)
 		if curAllocation := server.CurAllocation(); curAllocation != nil {
 			server.SetCurAllocation(server.Allocation().Clone())
 		}
 
-		// fmt.Printf("s=%s, rate=%v, tokens=%d \n",
-		// 	server.Name(), load.ArrivalRate, load.AvgLength)
+		// fmt.Printf("s=%s, rate=%v, inTokens=%d, outTokens=%d \n",
+		// 	server.Name(), load.ArrivalRate, load.AvgInTokens, load.AvgOutTokens)
 	}
 
 	system.Calculate()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -62,13 +62,25 @@ type ModelData struct {
 
 // Specifications for a combination of a model and accelerator data
 type ModelAcceleratorPerfData struct {
-	Name         string  `json:"name"`         // model name
-	Acc          string  `json:"acc"`          // accelerator name
-	AccCount     int     `json:"accCount"`     // number of accelerator units used by model
-	Alpha        float32 `json:"alpha"`        // alpha parameter of ITL
-	Beta         float32 `json:"beta"`         // beta parameter of ITL
-	MaxBatchSize int     `json:"maxBatchSize"` // max batch size based on average number of tokens per request
-	AtTokens     int     `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
+	Name         string       `json:"name"`         // model name
+	Acc          string       `json:"acc"`          // accelerator name
+	AccCount     int          `json:"accCount"`     // number of accelerator units used by model
+	MaxBatchSize int          `json:"maxBatchSize"` // max batch size based on average number of tokens per request
+	AtTokens     int          `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
+	DecodeParms  DecodeParms  `json:"decodeParms"`  // parameters for estimating decode time
+	PrefillParms PrefillParms `json:"prefillParms"` // parameters for estimating prefill time
+}
+
+// Parameters for estimating decode time = alpha + beta * batchSize (msec); batchSize > 0
+type DecodeParms struct {
+	Alpha float32 `json:"alpha"` // base
+	Beta  float32 `json:"beta"`  // slope
+}
+
+// Parameters for estimating prefill time = gamma + delta * inputTokens * batchSize (msec); inputTokens, batchSize > 0
+type PrefillParms struct {
+	Gamma float32 `json:"gamma"` // base
+	Delta float32 `json:"delta"` // slope
 }
 
 // Data related to a service class SLOs
@@ -85,10 +97,10 @@ type ServiceClassSpec struct {
 
 // Specification of SLO targets for a model
 type ModelTarget struct {
-	Model   string  `json:"model"`   // model name
-	SLO_ITL float32 `json:"slo-itl"` // inter-token latency (msec)
-	SLO_TTW float32 `json:"slo-ttw"` // request waiting time (msec)
-	SLO_TPS float32 `json:"slo-tps"` // throughput (tokens/sec)
+	Model    string  `json:"model"`    // model name
+	SLO_ITL  float32 `json:"slo-itl"`  // inter-token latency (msec)
+	SLO_TTFT float32 `json:"slo-ttft"` // time to first token, including queueing (msec)
+	SLO_TPS  float32 `json:"slo-tps"`  // throughput (tokens/sec)
 }
 
 // Data related to a Server
@@ -108,12 +120,26 @@ type ServerSpec struct {
 	DesiredAlloc    AllocationData `json:"desiredAlloc"`    // desired allocation
 }
 
+// Data about a server allocation
+type AllocationData struct {
+	Accelerator string         `json:"accelerator"` // accelerator name
+	NumReplicas int            `json:"numReplicas"` // number of replicas
+	MaxBatch    int            `json:"maxBatch"`    // max batch size
+	Cost        float32        `json:"cost"`        // cost of allocation
+	ITLAverage  float32        `json:"itlAverage"`  // average ITL
+	TTFTAverage float32        `json:"ttftAverage"` // average TTFT
+	Load        ServerLoadSpec `json:"load"`        // server load statistics
+}
+
 // Specifications of server load statistics
 type ServerLoadSpec struct {
-	ArrivalRate float32 `json:"arrivalRate"` // req/min
-	AvgLength   int     `json:"avgLength"`   // number of tokens
-	ArrivalCOV  float32 `json:"arrivalCOV"`  // coefficient of variation of inter-request arrival time
-	ServiceCOV  float32 `json:"serviceCOV"`  // coefficient of variation of request service time
+	ArrivalRate  float32 `json:"arrivalRate"`  // req/min
+	AvgInTokens  int     `json:"avgInTokens"`  // average number of input tokens
+	AvgOutTokens int     `json:"avgOutTokens"` // average number of output tokens
+}
+
+type AllocationSolution struct {
+	Spec map[string]AllocationData `json:"allocations"` // map of server names to allocation data
 }
 
 // Data related to Optimizer
@@ -126,19 +152,4 @@ type OptimizerSpec struct {
 	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
 	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
 	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
-}
-
-type AllocationSolution struct {
-	Spec map[string]AllocationData `json:"allocations"` // map of server names to allocation data
-}
-
-// Data about a server allocation
-type AllocationData struct {
-	Accelerator string         `json:"accelerator"` // accelerator name
-	NumReplicas int            `json:"numReplicas"` // number of replicas
-	MaxBatch    int            `json:"maxBatch"`    // max batch size
-	Cost        float32        `json:"cost"`        // cost of allocation
-	ITLAverage  float32        `json:"itlAverage"`  // average ITL
-	WaitAverage float32        `json:"waitAverage"` // average wait time
-	Load        ServerLoadSpec `json:"load"`        // server load statistics
 }

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -16,11 +16,11 @@ type Allocation struct {
 	batchSize   int     // max batch size
 	cost        float32 // cost of this allocation
 	value       float32 // value of this allocation
-	servTime    float32 // expected average token service time
-	waitTime    float32 // expected average request queueing time
+	itl         float32 // expected average token decode time (msec)
+	ttft        float32 // expected average request queueing and prefill times (msec)
 	rho         float32 // average concurrently running requests / max batch size
 
-	maxArrvRatePerReplica float32 // maximum arrival rate per replica
+	maxArrvRatePerReplica float32 // maximum arrival rate per replica (req/msec)
 }
 
 // Create an allocation of an accelerator to a server; nil if not feasible
@@ -47,7 +47,8 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 	if server = GetServer(serverName); server == nil {
 		return nil
 	}
-	if load = server.Load(); load == nil || load.ArrivalRate < 0 || load.AvgLength < 0 {
+	if load = server.Load(); load == nil || load.ArrivalRate < 0 ||
+		load.AvgInTokens < 0 || load.AvgOutTokens < 0 {
 		return nil
 	}
 
@@ -69,12 +70,12 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 	}
 
 	// handle zero traffic case
-	if load.ArrivalRate == 0 || load.AvgLength == 0 {
+	if load.ArrivalRate == 0 || load.AvgOutTokens == 0 {
 		return zeroLoadAllocation(server, model, acc, perf)
 	}
 
 	// calculate max batch size (N) based on average request length (K)
-	K := load.AvgLength
+	K := load.AvgOutTokens
 
 	// use maxBatchSize from configured value or scaled performance data
 	var N int
@@ -86,25 +87,23 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 	maxQueue := N * config.MaxQueueToBatchRatio
 
 	// create queue analyzer
-	// TODO: add data for gamma and delta prefill parameters
 	qConfig := &analyzer.Configuration{
 		MaxBatchSize: N,
 		MaxQueueSize: maxQueue,
 		ServiceParms: &analyzer.ServiceParms{
 			Prefill: &analyzer.PrefillParms{
-				Gamma: perf.Alpha,
-				Delta: perf.Beta,
+				Gamma: perf.PrefillParms.Gamma,
+				Delta: perf.PrefillParms.Delta,
 			},
 			Decode: &analyzer.DecodeParms{
-				Alpha: perf.Alpha,
-				Beta:  perf.Beta,
+				Alpha: perf.DecodeParms.Alpha,
+				Beta:  perf.DecodeParms.Beta,
 			},
 		},
 	}
 
-	// TODO: add input tokens for prefill
 	requestData := &analyzer.RequestSize{
-		AvgInputTokens:  1,
+		AvgInputTokens:  load.AvgInTokens,
 		AvgOutputTokens: K,
 	}
 
@@ -114,9 +113,11 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return nil
 	}
 
-	waitTimeLimit := target.TTW / config.SLOMargin // distribution of waiting time assumed exponential
+	// TODO: do we need this?
+	// waitTimeLimit := target.TTFT / config.SLOMargin // distribution of waiting time assumed exponential
+
 	targetPerf := &analyzer.TargetPerf{
-		TargetTTFT: waitTimeLimit,
+		TargetTTFT: target.TTFT,
 		TargetITL:  target.ITL,
 		TargetTPS:  target.TPS,
 	}
@@ -151,112 +152,14 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return nil
 	}
 	rho := metrics.Rho
-	servTime := metrics.AvgTokenTime
-	wait := metrics.AvgWaitTime
-	// fmt.Printf("numReplicas=%d; batchSize=%d; rate=%v, tokenTime=%v; wait=%v; \n", numReplicas, N, rate, servTime, wait)
+	itl := metrics.AvgTokenTime
+	ttft := metrics.AvgWaitTime + metrics.AvgPrefillTime
+	// fmt.Printf("numReplicas=%d; batchSize=%d; rate=%v, itl=%v; ttft=%v; \n", numReplicas, N, rate, itl, ttft)
 
 	alloc := &Allocation{accelerator: gName, numReplicas: numReplicas, batchSize: N,
-		cost: cost, servTime: servTime, waitTime: wait, rho: rho, maxArrvRatePerReplica: rateStar / 1000}
+		cost: cost, itl: itl, ttft: ttft, rho: rho, maxArrvRatePerReplica: rateStar / 1000}
 	alloc.SetValue(alloc.cost)
 	return alloc
-}
-
-// Change number of replicas in allocation and re-evaluate performance, assuming total load on a server
-func (a *Allocation) AdjustNumReplicas(numReplicas int, server *Server, model *Model) error {
-	if a.numReplicas < 1 || a.batchSize < 1 {
-		return fmt.Errorf("invalid current numReplicas (%d) or batchSize (%d)", a.numReplicas, a.batchSize)
-	}
-
-	// get load statistics
-	load := server.Load()
-	if load == nil {
-		return fmt.Errorf("missing server load spec for server %s", server.name)
-	}
-	K := load.AvgLength
-	totalRate := load.ArrivalRate / 60
-
-	// check if throughtput constrained
-	var target *Target
-	if svClass := GetServiceClass(server.ServiceClassName()); svClass != nil {
-		if target = svClass.ModelTarget(model.name); target != nil {
-			if target.TPS > 0 && K > 0 {
-				totalRate = target.TPS / float32(K)
-			}
-		}
-	}
-
-	// get performance parameters
-	perf := model.PerfData(a.accelerator)
-	if perf == nil {
-		return fmt.Errorf("missing performance data for model %s on accelerator %s", model.Name(), a.accelerator)
-	}
-
-	// calculate queue statistics
-	N := a.batchSize
-	maxQueue := N * config.MaxQueueToBatchRatio
-
-	// create queue analyzer
-	// TODO: add data for gamma and delta prefill parameters
-	qConfig := &analyzer.Configuration{
-		MaxBatchSize: N,
-		MaxQueueSize: maxQueue,
-		ServiceParms: &analyzer.ServiceParms{
-			Prefill: &analyzer.PrefillParms{
-				Gamma: perf.Alpha,
-				Delta: perf.Beta,
-			},
-			Decode: &analyzer.DecodeParms{
-				Alpha: perf.Alpha,
-				Beta:  perf.Beta,
-			},
-		},
-	}
-
-	// TODO: add input tokens for prefill
-	requestData := &analyzer.RequestSize{
-		AvgInputTokens:  1,
-		AvgOutputTokens: K,
-	}
-
-	queueAnalyzer, err := analyzer.NewQueueAnalyzer(qConfig, requestData)
-	if err != nil {
-		fmt.Println(err)
-		return nil
-	}
-
-	// analyze queue under load
-	rate := totalRate / float32(numReplicas)
-	var metrics *analyzer.AnalysisMetrics
-	if metrics, err = queueAnalyzer.Analyze(rate); err != nil {
-		fmt.Println(err)
-		return nil
-	}
-
-	// set allocation fields
-	a.rho = metrics.Rho
-	a.servTime = metrics.AvgTokenTime
-	a.waitTime = metrics.AvgWaitTime
-
-	// adjust cost and value
-	factor := float32(numReplicas) / float32(a.numReplicas)
-	a.cost *= factor
-	a.value *= factor
-
-	waitTimeLimit := target.TTW / config.SLOMargin // distribution of waiting time assumed exponential
-	targetPerf := &analyzer.TargetPerf{
-		TargetTTFT: waitTimeLimit,
-		TargetITL:  target.ITL,
-		TargetTPS:  target.TPS,
-	}
-
-	// determine max rates to satisfy targets
-	if _, metrics, _, err = queueAnalyzer.Size(targetPerf); err != nil {
-		// fmt.Println(err)
-		return nil
-	}
-	a.maxArrvRatePerReplica = metrics.Throughput / 1000
-	a.numReplicas = numReplicas
-	return nil
 }
 
 func (a *Allocation) Scale(serverName string) (alloc *Allocation, inc int) {
@@ -352,22 +255,34 @@ func (a *Allocation) Saturated(totalRate float32) bool {
 	return totalRate > float32(a.numReplicas)*a.MaxRPM()
 }
 
-// Allocation in case of zeroload
+// Allocation in case of zero load
 func zeroLoadAllocation(server *Server, model *Model, acc *Accelerator, perf *config.ModelAcceleratorPerfData) *Allocation {
+
+	numReplicas := server.minNumReplicas
+	gName := acc.Name()
+	if numReplicas == 0 {
+		alloc := &Allocation{accelerator: "", numReplicas: 0, batchSize: 0,
+			cost: 0, itl: 0, ttft: 0, rho: 0, maxArrvRatePerReplica: 0}
+		alloc.SetValue(0)
+		return alloc
+	}
+
 	maxBatchSize := perf.MaxBatchSize
 	if server.maxBatchSize > 0 {
 		maxBatchSize = server.maxBatchSize
 	}
-	numReplicas := server.minNumReplicas
-	gName := acc.Name()
 	totalNumInstances := model.NumInstances(gName) * numReplicas
 	cost := acc.Cost() * float32(totalNumInstances)
-	servTime := perf.Alpha + perf.Beta
-	minServTime := perf.Alpha + perf.Beta*float32(maxBatchSize)
-	maxArrvRatePerReplica := float32(maxBatchSize) / minServTime
+
+	//TODO: maxArrvRatePerReplica seems to be meaningless
+	decodeTime := perf.DecodeParms.Alpha + perf.DecodeParms.Beta
+	maxDecodeTime := perf.DecodeParms.Alpha + perf.DecodeParms.Beta*float32(maxBatchSize)
+	prefillTime := perf.PrefillParms.Gamma + perf.PrefillParms.Delta
+	maxServTime := prefillTime + maxDecodeTime
+	maxArrvRatePerReplica := float32(maxBatchSize) / maxServTime
 
 	alloc := &Allocation{accelerator: gName, numReplicas: numReplicas, batchSize: maxBatchSize,
-		cost: cost, servTime: servTime, waitTime: 0, rho: 0, maxArrvRatePerReplica: maxArrvRatePerReplica}
+		cost: cost, itl: decodeTime, ttft: prefillTime, rho: 0, maxArrvRatePerReplica: maxArrvRatePerReplica}
 	alloc.SetValue(alloc.cost)
 	return alloc
 }
@@ -391,8 +306,8 @@ func (a *Allocation) Clone() *Allocation {
 		batchSize:   a.batchSize,
 		cost:        a.cost,
 		value:       a.value,
-		servTime:    a.servTime,
-		waitTime:    a.waitTime,
+		itl:         a.itl,
+		ttft:        a.ttft,
 		rho:         a.rho,
 
 		maxArrvRatePerReplica: a.maxArrvRatePerReplica,
@@ -405,8 +320,8 @@ func (a *Allocation) AllocationData() *config.AllocationData {
 		NumReplicas: a.numReplicas,
 		MaxBatch:    a.batchSize,
 		Cost:        a.cost,
-		ITLAverage:  a.servTime,
-		WaitAverage: a.waitTime,
+		ITLAverage:  a.itl,
+		TTFTAverage: a.ttft,
 	}
 }
 
@@ -416,14 +331,14 @@ func AllocationFromData(data *config.AllocationData) *Allocation {
 		numReplicas: data.NumReplicas,
 		batchSize:   data.MaxBatch,
 		cost:        data.Cost,
-		servTime:    data.ITLAverage,
-		waitTime:    data.WaitAverage,
+		itl:         data.ITLAverage,
+		ttft:        data.TTFTAverage,
 	}
 }
 
 func (a *Allocation) String() string {
-	return fmt.Sprintf("{acc=%s; num=%d; maxBatch=%d; cost=%v, val=%v, servTime=%v, waitTime=%v, rho=%v, maxRPM=%v}",
-		a.accelerator, a.numReplicas, a.batchSize, a.cost, a.value, a.servTime, a.waitTime, a.rho, a.MaxRPM())
+	return fmt.Sprintf("{acc=%s; numRep=%d; maxBatch=%d; cost=%v, val=%v, itl=%v, ttft=%v, rho=%v, maxRPM=%v}",
+		a.accelerator, a.numReplicas, a.batchSize, a.cost, a.value, a.itl, a.ttft, a.rho, a.MaxRPM())
 }
 
 // Orchestration difference between two allocations

--- a/pkg/core/serviceclass.go
+++ b/pkg/core/serviceclass.go
@@ -15,14 +15,14 @@ type ServiceClass struct {
 
 // target SLOs for service class
 type Target struct {
-	ITL float32
-	TTW float32
-	TPS float32
+	ITL  float32
+	TTFT float32
+	TPS  float32
 }
 
 func (t *Target) String() string {
-	return fmt.Sprintf("[ITL=%v, TTW=%v, TPS=%v]",
-		t.ITL, t.TTW, t.TPS)
+	return fmt.Sprintf("[ITL=%v, TTFT=%v, TPS=%v]",
+		t.ITL, t.TTFT, t.TPS)
 }
 
 func NewServiceClass(name string, priority int) *ServiceClass {
@@ -71,9 +71,9 @@ func (c *ServiceClass) UpdateModelTargets(spec *config.ServiceClassSpec) bool {
 func (c *ServiceClass) AddModelTarget(spec *config.ModelTarget) *Target {
 	modelName := spec.Model
 	target := &Target{
-		ITL: spec.SLO_ITL,
-		TTW: spec.SLO_TTW,
-		TPS: spec.SLO_TPS,
+		ITL:  spec.SLO_ITL,
+		TTFT: spec.SLO_TTFT,
+		TPS:  spec.SLO_TPS,
 	}
 	c.targets[modelName] = target
 	return target
@@ -88,10 +88,10 @@ func (c *ServiceClass) Spec() config.ServiceClassSpec {
 	i := 0
 	for modelName, target := range c.targets {
 		modelTargets[i] = config.ModelTarget{
-			Model:   modelName,
-			SLO_ITL: target.ITL,
-			SLO_TTW: target.TTW,
-			SLO_TPS: target.TPS,
+			Model:    modelName,
+			SLO_ITL:  target.ITL,
+			SLO_TTFT: target.TTFT,
+			SLO_TPS:  target.TPS,
 		}
 		i++
 	}

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -365,10 +365,11 @@ func (s *System) String() string {
 		}
 		totalCost += alloc.cost
 		rate := load.ArrivalRate
-		tokens := load.AvgLength
-		fmt.Fprintf(&b, "s=%s; c=%s; m=%s; rate=%v; tk=%d; sol=%d, sat=%v, alloc=%v; ",
-			serverName, srvClassName, modelName, rate, tokens, len(server.allAllocations), server.Saturated(), alloc)
-		fmt.Fprintf(&b, "slo-itl=%v, slo-ttw=%v, slo-tps=%v \n", target.ITL, target.TTW, target.TPS)
+		inTokens := load.AvgInTokens
+		outTokens := load.AvgOutTokens
+		fmt.Fprintf(&b, "s=%s; c=%s; m=%s; rate=%v; inTk=%d; outTk=%d; sol=%d, sat=%v, alloc=%v; ",
+			serverName, srvClassName, modelName, rate, inTokens, outTokens, len(server.allAllocations), server.Saturated(), alloc)
+		fmt.Fprintf(&b, "slo-itl=%v, slo-ttft=%v, slo-tps=%v \n", target.ITL, target.TTFT, target.TPS)
 	}
 
 	b.WriteString("AllocationByType: \n")

--- a/pkg/solver/greedy.go
+++ b/pkg/solver/greedy.go
@@ -132,6 +132,9 @@ func allocate(entries []*serverEntry,
 		alloc := top.allocations[top.curIndex]
 		gName := alloc.Accelerator()
 		acc := core.GetAccelerator(gName)
+		if acc == nil {
+			continue
+		}
 		tName := acc.Type()
 		unitsPerReplica := model.NumInstances(gName) * acc.Spec().Multiplicity
 		count := alloc.NumReplicas() * unitsPerReplica

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -78,7 +78,6 @@ func (s *Solver) SolveUnlimited() {
 	}
 }
 
-
 func (s *Solver) AllocationDiff() map[string]*core.AllocationDiff {
 	return s.diffAllocation
 }

--- a/rest-server/README.md
+++ b/rest-server/README.md
@@ -77,28 +77,46 @@ The following data is needed by the Optimizer (Declarations described [types](..
             "name": "granite_13b",
             "acc": "A100",
             "accCount": 1,
-            "alpha": 20.58,
-            "beta": 0.41,
             "maxBatchSize": 32,
-            "atTokens": 512
+            "atTokens": 512,
+            "decodeParms": {
+                "alpha": 20.58,
+                "beta": 0.41
+            },
+            "prefillParms": {
+                "gamma": 200,
+                "delta": 0.021
+            }
             },
             {
             "name": "granite_13b",
             "acc": "G2",
             "accCount": 1,
-            "alpha": 17.15,
-            "beta": 0.34,
             "maxBatchSize": 38,
-            "atTokens": 512
+            "atTokens": 512,
+            "decodeParms": {
+                "alpha": 17.15,
+                "beta": 0.34
+            },
+            "prefillParms": {
+                "gamma": 170,
+                "delta": 0.017
+            }
             },
             {
             "name": "llama_70b",
             "acc": "G2",
             "accCount": 2,
-            "alpha": 22.84,
-            "beta": 5.89,
             "maxBatchSize": 6,
-            "atTokens": 512
+            "atTokens": 512,
+            "decodeParms": {
+                "alpha": 22.84,
+                "beta": 5.89
+            },
+            "prefillParms": {
+                "gamma": 220,
+                "delta": 0.295
+            }
             }
         ]
     }
@@ -107,9 +125,10 @@ The following data is needed by the Optimizer (Declarations described [types](..
     Performance data includes
 
    - `accCount`: number of accelerator (cards)
-   - `alpha` and `beta`: parameters (in msec) of the linear approximation of inter-token latency (ITL) as a function of the batch size (n), *ITL = alpha + beta . n*
    - `maxBatchSize`: maximum batch size to use, beyond which performance deteriorates
    - `atTokens`: average number of tokens used when determining the `maxBatchSize`
+   - `decodeParams`: decode parameters `alpha` and `beta` (in msec) of the linear approximation of inter-token latency (ITL) as a function of the batch size (n), *ITL = alpha + beta . n*
+   - `prefillParams`: prefill parameters `gamma` and `delta` (in msec) of the linear approximation of prefill time as a function of the number of input tokens (k) and the batch size (n), *Prefill = gamma + delta . k . n*
 
 1. **Service class data**: For all service classes, the specification, such as name, priority, and SLO targets for a service class. An example follows.
 
@@ -123,12 +142,12 @@ The following data is needed by the Optimizer (Declarations described [types](..
                     {
                         "model": "granite_13b",
                         "slo-itl": 40,
-                        "slo-ttw": 500
+                        "slo-ttft": 1000
                     },
                     {
                         "model": "llama_70b",
                         "slo-itl": 80,
-                        "slo-ttw": 500
+                        "slo-ttft": 1000
                     }
                 ]
             },
@@ -139,7 +158,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
                     {
                         "model": "granite_13b",
                         "slo-itl": 80,
-                        "slo-ttw": 1000
+                        "slo-ttft": 2000
                     }
                 ]
             },
@@ -149,7 +168,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
                 "modelTargets": [
                     {
                         "model": "mixtral_8_7b",
-                        "slo-tps": 2000
+                        "slo-tps": 4000
                     }
                 ]
             }
@@ -164,10 +183,10 @@ The following data is needed by the Optimizer (Declarations described [types](..
 
       - `name`: name of model
       - `slo-itl`: target SLO for ITL (msec)
-      - `slo-ttw` target SLO for request waiting (queueing) time (msec)
+      - `slo-ttft` target SLO TTFT, including queueing time (msec)
       - `slo-tps` target SLO for throughput (tokens/sec)
 
-1. **Server data**: For all inference servers, the name of the server, the model and service class it serves (currently, assuming a single model and service class per server), an option to not change the accelerator, a minimum number of replicas, a maximum batch size, and current and desired allocations. The current allocation reflects the state of the server and the desired allocation is provided by the Optimizer (as a solution to an optimization problem). An allocation includes accelerator, number of replicas, maximum batch size, cost, and observed or anticipated average ITL and waiting time, as well as load data. The load data includes statistical metrics about request arrivals and message lengths (number of tokens). An example follows.
+1. **Server data**: For all inference servers, the name of the server, the model and service class it serves (currently, assuming a single model and service class per server), an option to not change the accelerator, a minimum number of replicas, a maximum batch size, and current and desired allocations. The current allocation reflects the state of the server and the desired allocation is provided by the Optimizer (as a solution to an optimization problem). An allocation includes accelerator, number of replicas, maximum batch size, cost, and observed or anticipated average ITL and TTFT times, as well as load data. The load data includes statistical metrics about request arrivals and message lengths (number of input and output tokens). An example follows.
 
     ```json
     {
@@ -184,12 +203,11 @@ The following data is needed by the Optimizer (Declarations described [types](..
                     "maxBatch": 16,
                     "cost": 40,
                     "itlAverage": 25.2,
-                    "waitAverage": 726.5,
+                    "ttftAverage": 726.5,
                     "load": {
                         "arrivalRate": 100,
-                        "avgLength": 999,
-                        "arrivalCOV": 1.0,
-                        "serviceCOV": 1.0
+                        "avgInTokens": 128,
+                        "avgOutTokens": 999
                     }
                 },
                 "desiredAlloc": {
@@ -198,12 +216,11 @@ The following data is needed by the Optimizer (Declarations described [types](..
                     "maxBatch": 19,
                     "cost": 46,
                     "itlAverage": 21.16437,
-                    "waitAverage": 102.09766,
+                    "ttftAverage": 102.09766,
                     "load": {
                         "arrivalRate": 60,
-                        "avgLength": 1024,
-                        "arrivalCOV": 1.0,
-                        "serviceCOV": 1.0
+                        "avgInTokens": 96,
+                        "avgOutTokens": 1024
                     }
                 }
             }
@@ -247,12 +264,11 @@ The output of the Optimizer is an Allocation Solution, in addition to updating t
             "maxBatch": 19,
             "cost": 46,
             "itlAverage": 21.16437,
-            "waitAverage": 102.09766,
+            "ttftAverage": 102.09766,
             "load": {
                 "arrivalRate": 60,
-                "avgLength": 1024,
-                "arrivalCOV": 1.0,
-                "serviceCOV": 1.0
+                "avgInTokens": 96,
+                "avgOutTokens": 1024
             }
         }
     }

--- a/rest-server/handlers.go
+++ b/rest-server/handlers.go
@@ -256,10 +256,10 @@ func getServiceClassModelTarget(c *gin.Context) {
 		return
 	}
 	c.IndentedJSON(http.StatusOK, config.ModelTarget{
-		Model:   model,
-		SLO_ITL: target.ITL,
-		SLO_TTW: target.TTW,
-		SLO_TPS: target.TPS,
+		Model:    model,
+		SLO_ITL:  target.ITL,
+		SLO_TTFT: target.TTFT,
+		SLO_TPS:  target.TPS,
 	})
 }
 
@@ -278,10 +278,10 @@ func removeServiceClassModelTarget(c *gin.Context) {
 	}
 	svc.RemoveModelTarget(model)
 	c.IndentedJSON(http.StatusOK, config.ModelTarget{
-		Model:   model,
-		SLO_ITL: target.ITL,
-		SLO_TTW: target.TTW,
-		SLO_TPS: target.TPS,
+		Model:    model,
+		SLO_ITL:  target.ITL,
+		SLO_TTFT: target.TTFT,
+		SLO_TPS:  target.TPS,
 	})
 }
 


### PR DESCRIPTION
Model accelerator performance data to include parameters for both decode and prefill stages.

```
// Specifications for a combination of a model and accelerator data
type ModelAcceleratorPerfData struct {
	Name         string       `json:"name"`         // model name
	Acc          string       `json:"acc"`          // accelerator name
	AccCount     int          `json:"accCount"`     // number of accelerator units used by model
	MaxBatchSize int          `json:"maxBatchSize"` // max batch size based on average number of tokens per request
	AtTokens     int          `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
	DecodeParms  DecodeParms  `json:"decodeParms"`  // parameters for estimating decode time
	PrefillParms PrefillParms `json:"prefillParms"` // parameters for estimating prefill time
}

// Parameters for estimating decode time = alpha + beta * batchSize (msec); batchSize > 0
type DecodeParms struct {
	Alpha float32 `json:"alpha"` // base
	Beta  float32 `json:"beta"`  // slope
}

// Parameters for estimating prefill time = gamma + delta * inputTokens * batchSize (msec); inputTokens, batchSize > 0
type PrefillParms struct {
	Gamma float32 `json:"gamma"` // base
	Delta float32 `json:"delta"` // slope
}
```

Add SLO targets for TTFT, which is the time to first token, including queueing time.

```
// Specification of SLO targets for a model
type ModelTarget struct {
	Model    string  `json:"model"`    // model name
	SLO_ITL  float32 `json:"slo-itl"`  // inter-token latency (msec)
	SLO_TTFT float32 `json:"slo-ttft"` // time to first token, including queueing (msec)
	SLO_TPS  float32 `json:"slo-tps"`  // throughput (tokens/sec)
}
```

The load spec to include both input and output tokens.

```
// Specifications of server load statistics
type ServerLoadSpec struct {
	ArrivalRate  float32 `json:"arrivalRate"`  // req/min
	AvgInTokens  int     `json:"avgInTokens"`  // average number of input tokens
	AvgOutTokens int     `json:"avgOutTokens"` // average number of output tokens
}
```