### PR TITLE
Add MILP-related fields to OptimizerSpec

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -153,6 +153,9 @@ type OptimizerData struct {
 // Specifications for optimizer data
 type OptimizerSpec struct {
 	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
+	Heterogeneous     bool   `json:"heterogeneous"`     // heterogeneous accelerators assigned to same inference server
+	MILPSolver        bool   `json:"milpSolver"`        // use MILP solver to optimize
+	UseCplex          bool   `json:"useCplex"`          // use CPLEX solver for MILP problem
 	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
 	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -154,8 +154,8 @@ type OptimizerData struct {
 type OptimizerSpec struct {
 	Unlimited         bool   `json:"unlimited"`         // unlimited number of accelerator types (for capacity planning and/or cloud)
 	Heterogeneous     bool   `json:"heterogeneous"`     // heterogeneous accelerators assigned to same inference server
-	MILPSolver        bool   `json:"milpSolver"`        // use MILP solver to optimize
-	UseCplex          bool   `json:"useCplex"`          // use CPLEX solver for MILP problem
+	MILPSolver        bool   `json:"milpSolver"`        // use MILP solver to optimize (not supported in optimizer-light)
+	UseCplex          bool   `json:"useCplex"`          // use CPLEX solver for MILP problem (not supported in optimizer-light)
 	DelayedBestEffort bool   `json:"delayedBestEffort"` // delay best effort allocation after attempting allocation to all priority groups
 	SaturationPolicy  string `json:"saturationPolicy"`  // allocation policy under saturated condition
 }


### PR DESCRIPTION
## Summary
- Add `Heterogeneous`, `MILPSolver`, and `UseCplex` fields to `OptimizerSpec` in `pkg/config/types.go`
- These fields are needed by the full `optimizer` repo so it can share this config type directly
- optimizer-light ignores them; no behavior change

## Test Plan
- [x] `go build ./...` passes
- [x] `demos/main` demo runs and produces correct output