### PR TITLE
feat: guard zero perfParms in allocation; error return from Solve() on unresolved servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,13 @@ For each (Server, Accelerator) candidate:
 3. `QueueAnalyzer.Analyze(rate)` computes expected metrics for the solution.
 4. Infeasible if no batch size meets SLOs or GPU count × replicas exceeds available capacity.
 
+**Robustness guards:**
+- **Zero perfParms guard** (`CreateAllocation`): returns `nil` immediately when `Alpha == Beta == Gamma == 0`. All-zero parameters mean the EKF tuner has not yet provided valid values; passing them to the queue analyzer causes an infinite loop (service rate = +Inf → binary search never converges). The nil return causes the server/accelerator pair to be skipped.
+- **`Scale()` nil guard**: checks for a `nil` return from `CreateAllocation` before dereferencing; returns `(nil, 0)`.
+- **div-by-zero in `zeroLoadAllocation`**: `maxArrvRatePerReplica` is set to `0` when `maxServTime == 0`, preventing `+Inf` from entering the queue model.
+
+`Solver.Solve()` returns `fmt.Errorf("no feasible allocation for servers: [%s]", ...)` when any server has no feasible allocation after all candidates are evaluated. This error propagates through `Manager.Optimize()` to the REST layer (HTTP 404).
+
 ### REST API Modes
 
 **Stateless** (default): Single endpoint `/optimizeOne` accepts a full `SystemSpec` + optimizer params, returns solution. No state persists.
@@ -94,3 +101,13 @@ Six JSON files per dataset in `sample-data/{small,large}/`:
 - `serviceclasses.json` — SLO definitions (ITL, TTFT, TPS targets per model)
 - `capacity.json` — available GPU counts by type
 - `optimizer.json` — optimizer settings (mode, batch sizes to try)
+
+## Testing
+
+```bash
+go test ./...
+```
+
+Key test files:
+- `pkg/core/allocation_test.go` — white-box tests for `CreateAllocation`: zero perfParms with non-zero load returns nil; zero perfParms with zero load returns a valid allocation (minimum replicas, no `+Inf` values).
+- `pkg/solver/solver_test.go` — black-box tests for `Solver.Solve()`: zero perfParms returns an error in both unlimited and greedy modes; valid perfParms returns nil.

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -74,6 +74,11 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return zeroLoadAllocation(server, model, acc, perf)
 	}
 
+	// guard: skip this model/accelerator combination if perfParms are uninitialized
+	if perf.PerfParms.Alpha == 0 && perf.PerfParms.Beta == 0 && perf.PerfParms.Gamma == 0 {
+		return nil
+	}
+
 	// calculate max batch size (N) based on average request length (K)
 	K := load.AvgOutTokens
 
@@ -181,6 +186,9 @@ func (a *Allocation) Scale(serverName string) (alloc *Allocation, inc int) {
 
 	// create new allocation
 	alloc = CreateAllocation(serverName, gName)
+	if alloc == nil {
+		return nil, 0
+	}
 	inc = alloc.numReplicas - a.numReplicas
 	return alloc, inc
 }
@@ -275,7 +283,10 @@ func zeroLoadAllocation(server *Server, model *Model, acc *Accelerator, perf *co
 	maxDecodeTime := perf.PerfParms.Alpha + perf.PerfParms.Beta*float32(maxBatchSize)
 	prefillTime := decodeTime + perf.PerfParms.Gamma*float32(maxBatchSize)
 	maxServTime := prefillTime + maxDecodeTime
-	maxArrvRatePerReplica := float32(maxBatchSize) / maxServTime
+	maxArrvRatePerReplica := float32(0)
+	if maxServTime > 0 {
+		maxArrvRatePerReplica = float32(maxBatchSize) / maxServTime
+	}
 
 	alloc := &Allocation{accelerator: gName, numReplicas: numReplicas, batchSize: maxBatchSize,
 		cost: cost, itl: decodeTime, ttft: prefillTime, rho: 0, maxArrvRatePerReplica: maxArrvRatePerReplica}

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -74,7 +74,9 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return zeroLoadAllocation(server, model, acc, perf)
 	}
 
-	// guard: skip this model/accelerator combination if perfParms are uninitialized
+	// guard: perfParms all-zero means the tuner has not yet converged;
+	// skip to avoid passing zero alpha/beta/gamma into the queue analyzer
+	// (which would produce degenerate/+Inf queue metrics or an infinite loop).
 	if perf.PerfParms.Alpha == 0 && perf.PerfParms.Beta == 0 && perf.PerfParms.Gamma == 0 {
 		return nil
 	}

--- a/pkg/core/allocation_test.go
+++ b/pkg/core/allocation_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/llm-inferno/optimizer-light/pkg/config"
+)
+
+// newTestSystem builds the minimal System for allocation tests:
+// one accelerator (H100), one model (m1) with given perfParms,
+// one service class (Premium) with ITL/TTFT targets for m1,
+// one server (s1) with the given load.
+func newTestSystem(perfParms config.PerfParms, arrivalRate float32, minReplicas int) {
+	sys := NewSystem()
+	TheSystem = sys
+
+	sys.SetAcceleratorsFromSpec(&config.AcceleratorData{
+		Spec: []config.AcceleratorSpec{
+			{Name: "H100", Type: "H100", Multiplicity: 1, Cost: 75},
+		},
+	})
+	sys.SetCapacityFromSpec(&config.CapacityData{
+		Count: []config.AcceleratorCount{{Type: "H100", Count: 8}},
+	})
+	sys.SetModelsFromSpec(&config.ModelData{
+		PerfData: []config.ModelAcceleratorPerfData{
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: 16, AtTokens: 512,
+				PerfParms: perfParms},
+		},
+	})
+	sys.SetServiceClassesFromSpec(&config.ServiceClassData{
+		Spec: []config.ServiceClassSpec{
+			{Name: "Premium", Priority: 1, ModelTargets: []config.ModelTarget{
+				{Model: "m1", SLO_ITL: 100, SLO_TTFT: 2000},
+			}},
+		},
+	})
+	sys.SetServersFromSpec(&config.ServerData{
+		Spec: []config.ServerSpec{
+			{Name: "s1", Class: "Premium", Model: "m1",
+				MinNumReplicas: minReplicas,
+				CurrentAlloc: config.AllocationData{
+					Load: config.ServerLoadSpec{
+						ArrivalRate:  arrivalRate,
+						AvgInTokens:  512,
+						AvgOutTokens: 512,
+					},
+				},
+			},
+		},
+	})
+}
+
+// Zero perfParms + non-zero load: CreateAllocation must return nil (guard fires).
+func TestCreateAllocation_ZeroPerfParms_NonZeroLoad_ReturnsNil(t *testing.T) {
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60, 1)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc != nil {
+		t.Errorf("expected nil allocation for zero perfParms with non-zero load, got %v", alloc)
+	}
+}
+
+// Zero perfParms + zero load: CreateAllocation must return non-nil (zeroLoadAllocation path,
+// perfParms not needed).
+func TestCreateAllocation_ZeroPerfParms_ZeroLoad_ReturnsNonNil(t *testing.T) {
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 0, 0)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc == nil {
+		t.Error("expected non-nil allocation for zero load even with zero perfParms")
+	}
+}
+
+// Zero perfParms + zero load + minReplicas > 0: zeroLoadAllocation must not produce +Inf
+// MaxArrvRatePerReplica (division-by-zero when maxServTime == 0).
+func TestCreateAllocation_ZeroPerfParms_ZeroLoad_NonZeroMinReplicas_NoInf(t *testing.T) {
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 0, 2)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc == nil {
+		t.Fatal("expected non-nil allocation for zero load with minReplicas=2")
+	}
+	if alloc.MaxArrvRatePerReplica() != 0 {
+		t.Errorf("expected MaxArrvRatePerReplica=0 for zero perfParms, got %v", alloc.MaxArrvRatePerReplica())
+	}
+}

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 
 	"github.com/llm-inferno/optimizer-light/pkg/config"
 	"github.com/llm-inferno/optimizer-light/pkg/core"
@@ -48,12 +50,21 @@ func (s *Solver) Solve() error {
 	// TODO: cleanup after trying MIP solver
 
 	s.diffAllocation = make(map[string]*core.AllocationDiff)
+	var unresolved []string
 	for serverName, server := range core.GetServers() {
 		curAlloc := s.currentAllocation[serverName]
 		desiredAlloc := server.Allocation()
 		if allocDiff := core.CreateAllocationDiff(curAlloc, desiredAlloc); allocDiff != nil {
 			s.diffAllocation[serverName] = allocDiff
 		}
+		if desiredAlloc == nil {
+			unresolved = append(unresolved, serverName)
+		}
+	}
+	// return error if any server could not be allocated
+	if len(unresolved) > 0 {
+		sort.Strings(unresolved)
+		return fmt.Errorf("no feasible allocation for servers: [%s]", strings.Join(unresolved, ", "))
 	}
 	return nil
 }

--- a/pkg/solver/solver_test.go
+++ b/pkg/solver/solver_test.go
@@ -1,0 +1,85 @@
+package solver_test
+
+import (
+	"testing"
+
+	"github.com/llm-inferno/optimizer-light/pkg/config"
+	"github.com/llm-inferno/optimizer-light/pkg/core"
+	"github.com/llm-inferno/optimizer-light/pkg/solver"
+)
+
+// newSolverTestSystem builds a system identical to Task 1's newTestSystem,
+// but exposed here since solver_test is an external test package.
+func newSolverTestSystem(perfParms config.PerfParms, arrivalRate float32) {
+	sys := core.NewSystem()
+	core.TheSystem = sys
+
+	sys.SetAcceleratorsFromSpec(&config.AcceleratorData{
+		Spec: []config.AcceleratorSpec{
+			{Name: "H100", Type: "H100", Multiplicity: 1, Cost: 75},
+		},
+	})
+	sys.SetCapacityFromSpec(&config.CapacityData{
+		Count: []config.AcceleratorCount{{Type: "H100", Count: 8}},
+	})
+	sys.SetModelsFromSpec(&config.ModelData{
+		PerfData: []config.ModelAcceleratorPerfData{
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: 16, AtTokens: 512,
+				PerfParms: perfParms},
+		},
+	})
+	sys.SetServiceClassesFromSpec(&config.ServiceClassData{
+		Spec: []config.ServiceClassSpec{
+			{Name: "Premium", Priority: 1, ModelTargets: []config.ModelTarget{
+				{Model: "m1", SLO_ITL: 100, SLO_TTFT: 2000},
+			}},
+		},
+	})
+	sys.SetServersFromSpec(&config.ServerData{
+		Spec: []config.ServerSpec{
+			{Name: "s1", Class: "Premium", Model: "m1",
+				MinNumReplicas: 1,
+				CurrentAlloc: config.AllocationData{
+					Load: config.ServerLoadSpec{
+						ArrivalRate:  arrivalRate,
+						AvgInTokens:  512,
+						AvgOutTokens: 512,
+					},
+				},
+			},
+		},
+	})
+	sys.Calculate()
+}
+
+// When a server has no valid allocations (zero perfParms + non-zero load),
+// Solve() must return a non-nil error naming the unresolved server.
+func TestSolve_ZeroPerfParms_ReturnsError(t *testing.T) {
+	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60)
+	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: true})
+	err := s.Solve()
+	if err == nil {
+		t.Error("expected error when server has no feasible allocation, got nil")
+	}
+}
+
+// When a server has valid perfParms and load, Solve() must return nil (success).
+func TestSolve_ValidPerfParms_ReturnsNil(t *testing.T) {
+	newSolverTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 60)
+	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: true})
+	err := s.Solve()
+	if err != nil {
+		t.Errorf("expected nil error for valid perfParms, got: %v", err)
+	}
+}
+
+// When a server has no valid allocations and the greedy solver is used,
+// Solve() must also return a non-nil error naming the unresolved server.
+func TestSolveGreedy_ZeroPerfParms_ReturnsError(t *testing.T) {
+	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60)
+	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: false})
+	err := s.Solve()
+	if err == nil {
+		t.Error("expected error from greedy solver with zero perfParms, got nil")
+	}
+}


### PR DESCRIPTION
Closes #9

## Summary
- `CreateAllocation` returns `nil` immediately when all perfParms are zero, preventing infinite loops in the queue analyzer binary search
- Fixed latent nil-pointer dereference in `Scale()` when `CreateAllocation` returns nil
- Fixed potential div-by-zero in `zeroLoadAllocation` when `maxServTime == 0`
- `Solver.Solve()` returns a descriptive error when any server has no feasible allocation after candidate evaluation
- Added tests in `pkg/core/allocation_test.go` and `pkg/solver/solver_test.go`
- Updated CLAUDE.md with robustness guard documentation and Testing section

## Test plan
- [ ] `go test ./pkg/core/...` — 3 allocation tests pass (zero-load, non-zero-load, min-replicas)
- [ ] `go test ./pkg/solver/...` — 3 solver tests pass (unlimited error, greedy error, valid params)
- [ ] `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)