### PR TITLE
feat: decouple maxQueueSize from maxBatchSize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor/
 # Miscellaneous
 .DS_Store
 ~*
+
+# Git worktrees
+.worktrees/

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -14,9 +14,6 @@ var SLOPercentile = 0.95
 // Multiplier of average of exponential distribution to attain percentile
 var SLOMargin = -float32(math.Log(1 - SLOPercentile))
 
-// maximum number of requests in queueing system as multiples of maximum batch size
-var MaxQueueToBatchRatio = 10
-
 // default maximum number of tokens in a batch (passed to LLMQueueAnalyzer)
 const DefaultMaxNumTokens = 8192
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -119,6 +119,7 @@ type ServerSpec struct {
 	KeepAccelerator bool           `json:"keepAccelerator"` // option to not change accelerator
 	MinNumReplicas  int            `json:"minNumReplicas"`  // minimum number of replicas
 	MaxBatchSize    int            `json:"maxBatchSize"`    // overriding value for the maximum batch size
+	MaxQueueSize    int            `json:"maxQueueSize"`    // maximum external queue size (0 = no external queue)
 	CurrentAlloc    AllocationData `json:"currentAlloc"`    // current allocation
 	DesiredAlloc    AllocationData `json:"desiredAlloc"`    // desired allocation
 }

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -91,7 +91,7 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 	} else {
 		N = max(perf.MaxBatchSize*perf.AtTokens/K, 1)
 	}
-	maxQueue := N * config.MaxQueueToBatchRatio
+	maxQueue := server.maxQueueSize
 
 	// create queue analyzer
 	qConfig := &analyzer.Configuration{

--- a/pkg/core/server.go
+++ b/pkg/core/server.go
@@ -14,6 +14,7 @@ type Server struct {
 	keepAccelerator  bool
 	minNumReplicas   int
 	maxBatchSize     int
+	maxQueueSize     int
 
 	// server load statistics
 	load *config.ServerLoadSpec
@@ -44,6 +45,7 @@ func NewServerFromSpec(spec *config.ServerSpec) *Server {
 		keepAccelerator:  spec.KeepAccelerator,
 		minNumReplicas:   spec.MinNumReplicas,
 		maxBatchSize:     spec.MaxBatchSize,
+		maxQueueSize:     spec.MaxQueueSize,
 
 		allAllocations: map[string]*Allocation{},
 		curAllocation:  AllocationFromData(&spec.CurrentAlloc),


### PR DESCRIPTION
## Summary

- Remove `MaxQueueToBatchRatio` (an arbitrary 10× heuristic with no grounding in reality)
- Add `MaxQueueSize int \`json:"maxQueueSize"\`` to `ServerSpec`, mirroring the existing `MaxBatchSize` override pattern
- Store `maxQueueSize` on `Server`, populated from spec in `NewServerFromSpec`
- Use `server.maxQueueSize` directly in `allocation.go` instead of computing from the ratio

## Behavior

`maxQueueSize` defaults to 0 (Go zero value for omitted JSON field) = no external queue. This is consistent with the same default change made in `server-sim`'s `queue-analysis-evaluator` (`DEFAULT_MAX_QUEUE_SIZE` now defaults to 0).

**Existing server specs require no changes** — omitting `maxQueueSize` gives 0, which is the correct default for vLLM deployments with no external queue. Set it explicitly only when an external queue exists in front of the server.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all passing (pkg/core, pkg/solver)
- [x] No remaining references to `MaxQueueToBatchRatio`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)