### PR TITLE
Use queue-analyzer OptimalConcurrency to choose max batch size

### DIFF
--- a/demos/generators/main.go
+++ b/demos/generators/main.go
@@ -71,30 +71,6 @@ func main() {
 		{0.13, 0.16, 0.26, 0.20, 0.27, 0.18, 2.21, 0.13, 1.88},
 	}
 
-	maxBatchSize := [][]int{
-		{51, 38, 19, 102, 51, 25, 8, 102, 12},
-		{9, 7, 3, 19, 9, 4, 1, 19, 2},
-		{19, 14, 7, 38, 19, 9, 3, 38, 4},
-		{25, 19, 9, 51, 25, 12, 4, 51, 6},
-		{32, 24, 12, 64, 32, 16, 5, 64, 8},
-		{38, 28, 14, 76, 38, 19, 6, 76, 9},
-		{51, 38, 19, 102, 51, 25, 8, 102, 12},
-		{32, 24, 12, 64, 32, 16, 5, 64, 8},
-		{76, 57, 28, 153, 76, 38, 12, 153, 19},
-		{51, 38, 19, 102, 51, 25, 8, 102, 12},
-		{25, 19, 9, 51, 25, 12, 4, 51, 6},
-		{32, 24, 12, 64, 32, 16, 5, 64, 8},
-		{38, 28, 14, 76, 38, 19, 6, 76, 9},
-		{51, 38, 19, 102, 51, 25, 8, 102, 12},
-		{32, 24, 12, 64, 32, 16, 5, 64, 8},
-		{76, 57, 28, 153, 76, 38, 12, 153, 19},
-		{51, 38, 19, 102, 51, 25, 8, 102, 13},
-		{25, 19, 9, 51, 25, 13, 4, 51, 6},
-		{32, 24, 12, 64, 32, 16, 5, 64, 8},
-		{38, 29, 14, 77, 38, 19, 6, 77, 9},
-		{51, 38, 19, 102, 51, 25, 8, 102, 13},
-	}
-
 	count := [][]int{
 		{1, 1, 1, 1, 1, 1, 2, 1, 2},
 		{2, 4, 4, 1, 2, 4, 8, 1, 8},
@@ -119,9 +95,6 @@ func main() {
 		{1, 1, 1, 1, 1, 1, 1, 1, 1},
 	}
 
-	atTokens := 512
-
-	batchSizeFactor := 2
 	betaFactor := float32(10)
 	gammaFactor := float32(320)
 
@@ -136,7 +109,6 @@ func main() {
 
 		alpha = MaskMatrix(alpha, accMask, modMask)
 		beta = MaskMatrix(beta, accMask, modMask)
-		maxBatchSize = MaskMatrix(maxBatchSize, accMask, modMask)
 		count = MaskMatrix(count, accMask, modMask)
 	}
 
@@ -153,8 +125,7 @@ func main() {
 				Name:         n,
 				Acc:          a,
 				AccCount:     count[j][i],
-				MaxBatchSize: maxBatchSize[j][i] * batchSizeFactor,
-				AtTokens:     atTokens,
+				MaxBatchSize: config.DefaultConcurrencyCeiling,
 				PerfParms: config.PerfParms{
 					Alpha: alpha[j][i],
 					Beta:  beta[j][i] / betaFactor,

--- a/docs/superpowers/plans/2026-06-15-optimal-concurrency-batch-size.md
+++ b/docs/superpowers/plans/2026-06-15-optimal-concurrency-batch-size.md
@@ -1,0 +1,532 @@
+# Optimal-Concurrency Batch-Size Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Optimizer's linear-in-tokens max-batch-size heuristic with the queue analyzer's `OptimalConcurrency` search (queue-analysis PR #19), using `perf.MaxBatchSize` as the per-(model,accelerator) search ceiling.
+
+**Architecture:** In `CreateAllocation`, when there is no explicit `server.maxBatchSize` override, build a queue analyzer at a generous ceiling and call `OptimalConcurrency(targetPerf)` to obtain the minimum concurrency `M*` reaching near-peak throughput under the SLO; use `M*` as the max batch size. Infeasible SLO ⇒ skip the candidate. The `perf.AtTokens` field and the linear formula are retired.
+
+**Tech Stack:** Go 1.24, `github.com/llm-inferno/queue-analysis` (PR #19, via local `replace`), Go's built-in `testing`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-optimal-concurrency-batch-size-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `go.mod` — add `replace` directive to the local `queue-analysis` checkout.
+- **Modify** `pkg/config/defaults.go` — add `DefaultConcurrencyCeiling` constant.
+- **Modify** `pkg/core/allocation.go` — replace the `N` computation in `CreateAllocation` with the override-or-search logic.
+- **Modify** `pkg/config/types.go` — re-comment `MaxBatchSize`; remove `AtTokens`.
+- **Modify** `pkg/core/allocation_test.go` — parameterize the test helper; add feasible/infeasible search tests; drop `AtTokens`.
+- **Modify** `pkg/solver/solver_test.go` — update the duplicate helper; drop `AtTokens`.
+- **Modify** `demos/generators/main.go` — emit a generous ceiling; drop `AtTokens` and the now-unused benchmark matrix.
+- **Modify** `sample-data/{small,large}/model-data.json`, `sample-data/small/system-data.json` — drop `atTokens`, set generous `maxBatchSize`.
+- **Modify** `rest-server/README.md` — documentation only (payloads + field descriptions).
+
+---
+
+## Task 1: Wire up the dependency and add the ceiling constant
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `pkg/config/defaults.go`
+
+- [ ] **Step 1: Add the `replace` directive to `go.mod`**
+
+Append to the end of `go.mod`:
+
+```
+replace github.com/llm-inferno/queue-analysis => ../queue-analysis
+```
+
+- [ ] **Step 2: Tidy modules**
+
+Run: `go mod tidy`
+Expected: completes without error; `go.mod` keeps the `require github.com/llm-inferno/queue-analysis` line (the `replace` redirects resolution to the local checkout containing PR #19).
+
+- [ ] **Step 3: Verify the new symbol resolves**
+
+Run: `go doc github.com/llm-inferno/queue-analysis/pkg/analyzer.LLMQueueAnalyzer.OptimalConcurrency`
+Expected: prints the method signature `func (qa *LLMQueueAnalyzer) OptimalConcurrency(target *TargetPerf) (*ConcurrencyResult, error)`. If it errors with "no such symbol", the `replace` path or the local checkout is wrong — stop and fix before continuing.
+
+- [ ] **Step 4: Add `DefaultConcurrencyCeiling` to `pkg/config/defaults.go`**
+
+Insert after line 18 (the `DefaultMaxNumTokens` constant):
+
+```go
+// default upper bound (search ceiling) for the optimal-concurrency search;
+// used when a (model,accelerator)'s perf.MaxBatchSize is 0/unset
+const DefaultConcurrencyCeiling = 256
+```
+
+- [ ] **Step 5: Verify the build**
+
+Run: `go build ./...`
+Expected: builds cleanly (no code uses the new symbol or constant yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go.mod go.sum pkg/config/defaults.go
+git commit -m "build: vendor queue-analysis PR #19 via replace; add DefaultConcurrencyCeiling
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Switch `CreateAllocation` to the optimal-concurrency search
+
+**Files:**
+- Modify: `pkg/core/allocation_test.go`
+- Modify: `pkg/core/allocation.go:84-134`
+
+- [ ] **Step 1: Parameterize the test helper (no behavior change)**
+
+In `pkg/core/allocation_test.go`, change the helper signature to accept the per-(model,accelerator) ceiling, and use it in the model spec. Replace the signature line and the `SetModelsFromSpec` block:
+
+```go
+func newTestSystem(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32, minReplicas int) {
+```
+
+and
+
+```go
+	sys.SetModelsFromSpec(&config.ModelData{
+		PerfData: []config.ModelAcceleratorPerfData{
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize, AtTokens: 512,
+				PerfParms: perfParms},
+		},
+	})
+```
+
+Update the three existing callers to pass a generous ceiling (`256`):
+
+- `TestCreateAllocation_ZeroPerfParms_NonZeroLoad_ReturnsNil`: `newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60, 1)`
+- `TestCreateAllocation_ZeroPerfParms_ZeroLoad_ReturnsNonNil`: `newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 0, 0)`
+- `TestCreateAllocation_ZeroPerfParms_ZeroLoad_NonZeroMinReplicas_NoInf`: `newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 0, 2)`
+
+- [ ] **Step 2: Run the existing tests to confirm the refactor is green**
+
+Run: `go test ./pkg/core/ -run TestCreateAllocation -v`
+Expected: the three existing tests PASS (helper refactor changed no behavior).
+
+- [ ] **Step 3: Write the failing red-green test for the searched concurrency**
+
+Append to `pkg/core/allocation_test.go`:
+
+```go
+// No benchmark (perf.MaxBatchSize == 0) + valid perfParms + lenient SLOs:
+// the analyzer's optimal-concurrency search must pick a batch size > 1.
+// The OLD linear formula computed N = max(0*AtTokens/K, 1) = 1, so this
+// asserts the new search path is in effect.
+func TestCreateAllocation_NoBenchmark_UsesSearchedConcurrency(t *testing.T) {
+	newTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 0, 60, 1)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc == nil {
+		t.Fatal("expected a feasible allocation with valid perfParms and lenient SLOs")
+	}
+	if alloc.MaxBatchSize() <= 1 {
+		t.Errorf("expected searched concurrency > 1, got %d", alloc.MaxBatchSize())
+	}
+	if alloc.MaxBatchSize() > config.DefaultConcurrencyCeiling {
+		t.Errorf("batch size %d exceeds search ceiling %d", alloc.MaxBatchSize(), config.DefaultConcurrencyCeiling)
+	}
+	if alloc.NumReplicas() < 1 {
+		t.Errorf("expected at least 1 replica, got %d", alloc.NumReplicas())
+	}
+}
+
+// Infeasible SLO (ITL target below what any batch size can achieve):
+// CreateAllocation must return nil (skip), never an allocation pinned to
+// the search's MMin=1 fallback.
+func TestCreateAllocation_InfeasibleSLO_ReturnsNil(t *testing.T) {
+	newTestSystemWithTargets(config.PerfParms{Alpha: 50, Beta: 1, Gamma: 0.1}, 256, 60, 1,
+		0.001 /*SLO_ITL*/, 0.001 /*SLO_TTFT*/)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc != nil {
+		t.Errorf("expected nil for an unachievable SLO, got %v", alloc)
+	}
+}
+```
+
+Add a targets-aware helper variant just below `newTestSystem` (the original delegates to it so existing behavior is unchanged):
+
+```go
+// newTestSystemWithTargets is newTestSystem with explicit ITL/TTFT SLO targets.
+func newTestSystemWithTargets(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32, minReplicas int, sloITL, sloTTFT float32) {
+	sys := NewSystem()
+	TheSystem = sys
+
+	sys.SetAcceleratorsFromSpec(&config.AcceleratorData{
+		Spec: []config.AcceleratorSpec{
+			{Name: "H100", Type: "H100", Multiplicity: 1, Cost: 75},
+		},
+	})
+	sys.SetCapacityFromSpec(&config.CapacityData{
+		Count: []config.AcceleratorCount{{Type: "H100", Count: 8}},
+	})
+	sys.SetModelsFromSpec(&config.ModelData{
+		PerfData: []config.ModelAcceleratorPerfData{
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize, AtTokens: 512,
+				PerfParms: perfParms},
+		},
+	})
+	sys.SetServiceClassesFromSpec(&config.ServiceClassData{
+		Spec: []config.ServiceClassSpec{
+			{Name: "Premium", Priority: 1, ModelTargets: []config.ModelTarget{
+				{Model: "m1", SLO_ITL: sloITL, SLO_TTFT: sloTTFT},
+			}},
+		},
+	})
+	sys.SetServersFromSpec(&config.ServerData{
+		Spec: []config.ServerSpec{
+			{Name: "s1", Class: "Premium", Model: "m1",
+				MinNumReplicas: minReplicas,
+				CurrentAlloc: config.AllocationData{
+					Load: config.ServerLoadSpec{
+						ArrivalRate:  arrivalRate,
+						AvgInTokens:  512,
+						AvgOutTokens: 512,
+					},
+				},
+			},
+		},
+	})
+}
+```
+
+Then replace the body of the original `newTestSystem` so it delegates (keeps its lenient `ITL: 100, TTFT: 2000` targets):
+
+```go
+func newTestSystem(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32, minReplicas int) {
+	newTestSystemWithTargets(perfParms, maxBatchSize, arrivalRate, minReplicas, 100, 2000)
+}
+```
+
+- [ ] **Step 4: Run the new test against the OLD implementation to confirm red**
+
+Run: `go test ./pkg/core/ -run TestCreateAllocation_NoBenchmark_UsesSearchedConcurrency -v`
+Expected: FAIL — old code computes `N = max(perf.MaxBatchSize*perf.AtTokens/K, 1) = max(0,1) = 1`, so `MaxBatchSize() == 1` trips the `expected searched concurrency > 1` assertion.
+
+- [ ] **Step 5: Replace the `N` computation in `CreateAllocation`**
+
+In `pkg/core/allocation.go`, replace lines 84–134 (from the `// calculate max batch size (N) ...` comment through the `rateStar := metrics.Throughput` line) with:
+
+```go
+	// average request output length
+	K := load.AvgOutTokens
+	maxQueue := server.maxQueueSize
+
+	serviceParms := &analyzer.ServiceParms{
+		Alpha: perf.PerfParms.Alpha,
+		Beta:  perf.PerfParms.Beta,
+		Gamma: perf.PerfParms.Gamma,
+	}
+	requestData := &analyzer.RequestSize{
+		AvgInputTokens:  float32(load.AvgInTokens),
+		AvgOutputTokens: float32(K),
+	}
+	targetPerf := &analyzer.TargetPerf{
+		TargetTTFT: target.TTFT,
+		TargetITL:  target.ITL,
+		TargetTPS:  target.TPS,
+	}
+
+	// determine max batch size (concurrency) N
+	var N int
+	if server.maxBatchSize > 0 {
+		// explicit override: use as-is, skip the search
+		N = server.maxBatchSize
+	} else {
+		// primary path: let the queue analyzer find the optimal concurrency
+		// (smallest max batch size reaching near-peak throughput under the SLO).
+		// perf.MaxBatchSize is the search ceiling; 0 => default ceiling.
+		ceiling := perf.MaxBatchSize
+		if ceiling <= 0 {
+			ceiling = config.DefaultConcurrencyCeiling
+		}
+		searchAnalyzer, err := analyzer.NewLLMQueueAnalyzer(&analyzer.Configuration{
+			MaxBatchSize: ceiling,
+			MaxNumTokens: config.DefaultMaxNumTokens,
+			MaxQueueSize: maxQueue,
+			ServiceParms: serviceParms,
+		}, requestData)
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+		res, err := searchAnalyzer.OptimalConcurrency(targetPerf)
+		if err != nil || res == nil || !res.Feasible {
+			// SLO unachievable within [1, ceiling]; skip this candidate.
+			return nil
+		}
+		N = res.Concurrency
+	}
+
+	// create queue analyzer at the chosen concurrency N
+	qConfig := &analyzer.Configuration{
+		MaxBatchSize: N,
+		MaxNumTokens: config.DefaultMaxNumTokens,
+		MaxQueueSize: maxQueue,
+		ServiceParms: serviceParms,
+	}
+
+	queueAnalyzer, err := analyzer.NewLLMQueueAnalyzer(qConfig, requestData)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
+	// determine max rates to satisfy targets
+	_, metrics, _, err := queueAnalyzer.Size(targetPerf)
+	if err != nil {
+		return nil
+	}
+	rateStar := metrics.Throughput
+```
+
+Note: this deletes the old standalone `targetPerf` block (and its `// TODO: do we need this?` comment) that previously sat between `NewLLMQueueAnalyzer` and `Size()`, since `targetPerf` is now built earlier. The code below `rateStar := metrics.Throughput` (replicas, cost, `Analyze`, struct construction) is unchanged.
+
+- [ ] **Step 6: Run the core tests to verify green**
+
+Run: `go test ./pkg/core/ -run TestCreateAllocation -v`
+Expected: all five tests PASS (three originals + `NoBenchmark_UsesSearchedConcurrency` + `InfeasibleSLO_ReturnsNil`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/core/allocation.go pkg/core/allocation_test.go
+git commit -m "feat: choose max batch size via queue-analyzer OptimalConcurrency
+
+Replace the linear-in-tokens heuristic with the optimal-concurrency
+search. perf.MaxBatchSize is now the search ceiling (default 256);
+explicit server.maxBatchSize still overrides. Infeasible SLO => skip.
+
+Refs #13
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Retire the `AtTokens` field
+
+**Files:**
+- Modify: `pkg/config/types.go:68-69`
+- Modify: `pkg/core/allocation_test.go`
+- Modify: `pkg/solver/solver_test.go`
+- Modify: `demos/generators/main.go`
+
+- [ ] **Step 1: Update `pkg/config/types.go`**
+
+Replace the two lines (68–69):
+
+```go
+	MaxBatchSize int       `json:"maxBatchSize"` // max batch size based on average number of tokens per request
+	AtTokens     int       `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
+```
+
+with:
+
+```go
+	MaxBatchSize int       `json:"maxBatchSize"` // search ceiling (max concurrency) for the optimal-concurrency search; 0 => DefaultConcurrencyCeiling (256)
+```
+
+- [ ] **Step 2: Remove `AtTokens` from the core test helpers**
+
+In `pkg/core/allocation_test.go`, both `SetModelsFromSpec` blocks (in `newTestSystem`'s delegate target `newTestSystemWithTargets` — there is now one such block) — change:
+
+```go
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize, AtTokens: 512,
+				PerfParms: perfParms},
+```
+
+to:
+
+```go
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize,
+				PerfParms: perfParms},
+```
+
+- [ ] **Step 3: Update the solver test helper**
+
+In `pkg/solver/solver_test.go`, change the helper signature and model spec to match the core helper. Replace the signature:
+
+```go
+func newSolverTestSystem(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32) {
+```
+
+Replace the model spec block:
+
+```go
+	sys.SetModelsFromSpec(&config.ModelData{
+		PerfData: []config.ModelAcceleratorPerfData{
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize,
+				PerfParms: perfParms},
+		},
+	})
+```
+
+Update the three callers to pass a generous ceiling (`256`):
+
+- `TestSolve_ZeroPerfParms_ReturnsError`: `newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60)`
+- `TestSolve_ValidPerfParms_ReturnsNil`: `newSolverTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 256, 60)`
+- `TestSolveGreedy_ZeroPerfParms_ReturnsError`: `newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60)`
+
+- [ ] **Step 4: Update `demos/generators/main.go`**
+
+Change the perf-data construction (lines ~156–157) from:
+
+```go
+				MaxBatchSize: maxBatchSize[j][i] * batchSizeFactor,
+				AtTokens:     atTokens,
+```
+
+to:
+
+```go
+				MaxBatchSize: config.DefaultConcurrencyCeiling,
+```
+
+Then remove the now-unused declarations so the file compiles (Go errors on unused locals):
+- the entire `maxBatchSize := [][]int{ ... }` literal (lines ~74–96),
+- `atTokens := 512` (line ~122),
+- `batchSizeFactor := 2` (line ~124),
+- the `maxBatchSize = MaskMatrix(maxBatchSize, accMask, modMask)` line inside the `useMask` block (line ~139).
+
+- [ ] **Step 5: Verify build, vet, and full test suite**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: all green. The solver `TestSolve_ValidPerfParms_ReturnsNil` exercises the new search path end-to-end (valid perfParms, ceiling 256, lenient SLOs ⇒ feasible).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/config/types.go pkg/core/allocation_test.go pkg/solver/solver_test.go demos/generators/main.go
+git commit -m "refactor: retire perf.AtTokens; perf.MaxBatchSize is the search ceiling
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Update sample data and REST documentation
+
+**Files:**
+- Modify: `sample-data/small/model-data.json`, `sample-data/large/model-data.json`, `sample-data/small/system-data.json`
+- Modify: `rest-server/README.md`
+
+- [ ] **Step 1: Rewrite the sample-data perf entries**
+
+Drop every `atTokens` key and set every perf-entry `maxBatchSize` to a generous ceiling (`256`) so the demos exercise a real search rather than pinning to a tight benchmarked value. Run:
+
+```bash
+tmp=$(mktemp)
+for f in sample-data/small/model-data.json sample-data/large/model-data.json; do
+  jq '(.models[]) |= (del(.atTokens) | .maxBatchSize = 256)' "$f" > "$tmp" && mv "$tmp" "$f"
+done
+jq '(.system.models[]) |= (del(.atTokens) | .maxBatchSize = 256)' sample-data/small/system-data.json > "$tmp" && mv "$tmp" sample-data/small/system-data.json
+```
+
+- [ ] **Step 2: Confirm no `atTokens` remains in sample-data**
+
+Run: `grep -rn "atTokens" sample-data/ || echo "clean"`
+Expected: `clean`.
+
+- [ ] **Step 3: Run the demo end-to-end**
+
+Run: `cd demos/main && go run main.go large; cd ../..`
+Expected: completes without error and prints a solution (per-server accelerator assignments, replicas, batch sizes). Batch sizes now reflect searched `M*` values, not the old benchmarked numbers.
+
+- [ ] **Step 4: Update `rest-server/README.md` — example payloads**
+
+In the model-data example block (lines ~74–113), remove all three `"atTokens": 512,` lines, and change the three `"maxBatchSize"` example values to `256` (i.e. `"maxBatchSize": 256,` for the `A100`, `G2`, and `llama_70b`/`G2` entries).
+
+- [ ] **Step 5: Update `rest-server/README.md` — field descriptions**
+
+Replace lines 119–120:
+
+```
+   - `maxBatchSize`: maximum batch size to use, beyond which performance deteriorates
+   - `atTokens`: average number of tokens used when determining the `maxBatchSize`
+```
+
+with:
+
+```
+   - `maxBatchSize`: search ceiling (max concurrency) for the optimal-concurrency search that sizes each server; `0` uses the default ceiling (256). An explicit per-server `maxBatchSize` override (in server data) bypasses the search.
+```
+
+(Leave the `accCount` and `perfParms` bullets unchanged.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sample-data/small/model-data.json sample-data/large/model-data.json sample-data/small/system-data.json rest-server/README.md
+git commit -m "docs+data: drop atTokens, use generous maxBatchSize ceiling in samples and README
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Final verification and pull request
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full verification sweep**
+
+Run: `gofmt -l . && go build ./... && go vet ./... && go test ./...`
+Expected: `gofmt -l .` prints nothing (all formatted); build, vet, and tests all green.
+
+- [ ] **Step 2: Confirm no stray references remain**
+
+Run: `grep -rn "AtTokens\|atTokens" --include="*.go" . ; grep -rn "MaxBatchSize\*" --include="*.go" .`
+Expected: no matches (the field and the linear formula are fully removed).
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push
+gh pr create --fill --base main \
+  --title "Use queue-analyzer OptimalConcurrency to choose max batch size" \
+  --body "$(cat <<'EOF'
+Closes #13.
+
+Replaces the linear-in-tokens max-batch-size heuristic with the queue analyzer's optimal-concurrency search (queue-analysis PR #19).
+
+- `perf.MaxBatchSize` is now the per-(model,accelerator) search ceiling (default 256); `perf.AtTokens` is retired.
+- Explicit `server.maxBatchSize` still overrides and skips the search.
+- Infeasible SLO ⇒ candidate is skipped.
+- Interim dependency via `replace => ../queue-analysis` until queue-analysis is tagged past v0.7.0.
+
+Design: `docs/superpowers/specs/2026-06-15-optimal-concurrency-batch-size-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: the `replace` directive points at a local sibling checkout and must not be merged as-is for consumers. Before merge, tag `queue-analysis` (e.g. `v0.8.0`), then swap the `replace` for a real `require` bump (`go get github.com/llm-inferno/queue-analysis@v0.8.0 && go mod tidy`). Call this out in the PR description / review.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Primary-path control flow → Task 2 (Step 5). ✓
+- `DefaultConcurrencyCeiling` → Task 1 (Step 4). ✓
+- Reuse `perf.MaxBatchSize` as ceiling + retire `AtTokens` → Task 2 (logic) + Task 3 (field). ✓
+- Infeasible ⇒ nil → Task 2 (Step 3 test + Step 5 logic). ✓
+- All-zero perfParms guard preserved → unchanged (above the replaced block); covered by existing tests carried in Task 2. ✓
+- Redundant-solve-accepted-for-simplicity → Task 2 Step 5 keeps the downstream `Size()`. ✓
+- Dependency `replace` → Task 1 + Task 5 merge note. ✓
+- `demos/generators`, `sample-data`, `rest-server/README.md` → Task 3 (generators) + Task 4. ✓
+- `zeroLoadAllocation` left as-is → not modified by any task (intentional). ✓
+- Tests in `pkg/core` + `pkg/solver` → Task 2 + Task 3. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full code. ✓
+
+**Type consistency:** `OptimalConcurrency(target *TargetPerf) (*ConcurrencyResult, error)`, `res.Concurrency`, `res.Feasible`, `config.DefaultConcurrencyCeiling`, helper signatures `newTestSystem(perfParms, maxBatchSize, arrivalRate, minReplicas)` / `newSolverTestSystem(perfParms, maxBatchSize, arrivalRate)` are used consistently across tasks. ✓

--- a/docs/superpowers/specs/2026-06-15-optimal-concurrency-batch-size-design.md
+++ b/docs/superpowers/specs/2026-06-15-optimal-concurrency-batch-size-design.md
@@ -1,0 +1,176 @@
+# Optimal-Concurrency Batch-Size Selection — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (design); pending implementation plan
+
+## Goal
+
+Replace the Optimizer's prior-benchmark + linear-in-tokens heuristic for choosing
+a server's max batch size (concurrency) with the queue analyzer's
+optimal-concurrency search added in
+[`llm-inferno/queue-analysis` PR #19](https://github.com/llm-inferno/queue-analysis/pull/19).
+
+Given model + workload + SLO targets, the analyzer now returns the **minimum
+concurrency `M*`** that reaches near-peak request throughput while still meeting
+the SLO. Operating below `M*` sacrifices throughput; operating above it
+over-provisions concurrency and reduces robustness to traffic surges. We want the
+Optimizer to use `M*` as the max batch size for each (server, accelerator)
+candidate.
+
+## Background — current behavior
+
+In `pkg/core/allocation.go` (`CreateAllocation`, lines ~84–93) the max batch size
+`N` is chosen as:
+
+```go
+K := load.AvgOutTokens
+if server.maxBatchSize > 0 {
+    N = server.maxBatchSize                       // explicit override
+} else {
+    N = max(perf.MaxBatchSize*perf.AtTokens/K, 1) // linear-in-tokens scaling
+}
+```
+
+`perf.MaxBatchSize` / `perf.AtTokens` (e.g. `18` measured at `512` tokens) come
+from offline benchmarking; `N` is scaled inversely with the actual average output
+length `K`. `N` then becomes `analyzer.Configuration.MaxBatchSize`, feeding
+`Size()` (max sustainable rate per replica) and `Analyze()` (expected metrics).
+
+## The new queue-analysis surface (PR #19)
+
+Consumed in-process as a Go library (we do **not** use the `/optimize` REST
+endpoint or its `OptimizeData` JSON shape):
+
+- `func (qa *LLMQueueAnalyzer) OptimalConcurrency(target *TargetPerf) (*ConcurrencyResult, error)`
+  — uses the analyzer's own `ServiceParms` / `RequestSize` and its
+  **`MaxBatchSize` as the search ceiling `m_max`**, returning the smallest
+  concurrency reaching near-peak throughput under the SLO.
+- `ConcurrencyResult` fields used here: `Concurrency` (= `M*`), `Feasible`
+  (false ⇒ SLO unreachable within `[1, ceiling]`, with `Concurrency` pinned to
+  `MMin`=1). Other fields (`Metrics`, `MITL`, `MTPF`, `AnchorThroughput`,
+  `Calls`, `Probes`, `Throughput`) are available but not required by this change.
+- The search's closed-form brackets use `TargetITL` and `TargetTTFT`; the oracle
+  (`Size()`) uses all three targets. The `TargetPerf` we already build is
+  therefore sufficient.
+
+**Critical semantic:** `MaxBatchSize` is the search *ceiling*, not a target. If
+the ceiling is set near the true optimum, the search has no room to descend and
+`Concurrency` simply pins to the ceiling. The ceiling must be **generous**.
+
+## Decisions (from brainstorming)
+
+1. **Role:** optimal-concurrency is the **primary** method — it replaces the
+   linear-scaling path entirely (not a fallback, not a toggle). The explicit
+   `server.maxBatchSize` override is retained.
+2. **Ceiling source:** reuse the existing per-(model,accelerator)
+   `perf.MaxBatchSize` field as the search ceiling, defaulting to `256` when
+   `0`/unset. This is the natural granularity for a hardware/KV-cache limit and a
+   ready hook for a future KV-cache-derived value. `perf.AtTokens` is retired.
+
+## Design
+
+### Control flow — `CreateAllocation` (`pkg/core/allocation.go`)
+
+Two cases for `N`:
+
+```
+if server.maxBatchSize > 0:          # explicit override — unchanged
+    N = server.maxBatchSize
+else:                                # NEW primary path
+    ceiling = perf.MaxBatchSize > 0 ? perf.MaxBatchSize : config.DefaultConcurrencyCeiling
+    searchQA = NewLLMQueueAnalyzer(config @ MaxBatchSize=ceiling, requestData)
+    res, err = searchQA.OptimalConcurrency(targetPerf)
+    if err != nil || !res.Feasible:  # SLO unreachable in [1, ceiling]
+        return nil                   # skip — joins existing "no feasible allocation" path
+    N = res.Concurrency              # = M*
+```
+
+Downstream is **unchanged**: build the analyzer at `MaxBatchSize=N`, call
+`Size()` → `rateStar`, compute replicas, `Analyze(perReplicaRate)` →
+itl/ttft/rho.
+
+- **Redundant solve, accepted for simplicity:** in the non-override path the
+  search already sizes at `M*`, and the downstream `Size()` re-sizes at `N=M*` —
+  one extra deterministic solve. We keep the downstream code identical rather
+  than thread `res.Metrics` through. Easy to optimize later if it matters.
+- **Minor reordering:** `maxQueue`, `requestData`, and `targetPerf` must be
+  constructed *before* the search.
+- **Guard preserved:** the all-zero-perfParms guard (α=β=γ=0 ⇒ return nil) stays
+  before the search; all-zero parameters would make the search degenerate too.
+- **Infeasible handling:** `err != nil || !res.Feasible` ⇒ `return nil`, matching
+  the existing skip semantics. We do **not** silently allocate at the pinned
+  `MMin`=1.
+
+### Config / types
+
+- `pkg/config/defaults.go`: add `const DefaultConcurrencyCeiling = 256`.
+- `pkg/config/types.go` (`ModelAcceleratorPerfData`):
+  - `MaxBatchSize` comment changes to: "search ceiling (max concurrency) for the
+    optimal-concurrency search; 0 ⇒ `DefaultConcurrencyCeiling` (256)".
+  - Remove the `AtTokens` field. Existing JSON carrying `atTokens` still parses
+    (unknown keys are ignored by `encoding/json`).
+
+### Dependency
+
+- Add `replace github.com/llm-inferno/queue-analysis => ../queue-analysis` and run
+  `go mod tidy`. PR #19 is merged on `queue-analysis/main` but the latest tag
+  (`v0.7.0`) predates it, so a local `replace` is the interim mechanism until a
+  new tag (e.g. `v0.8.0`) lands.
+
+### Other touched sites
+
+- `demos/generators/main.go`: stop emitting `atTokens`; set `MaxBatchSize` to a
+  generous ceiling (e.g. `256`) instead of the benchmarked `18`, otherwise the
+  search pins to the ceiling.
+- `sample-data/` (`small/model-data.json`, `large/model-data.json`,
+  `small/system-data.json`): remove `atTokens`; replace benchmarked `maxBatchSize`
+  values with a generous ceiling so the demos exercise a real search instead of
+  pinning to a tight value.
+- `rest-server/README.md` (**documentation only — no Go changes in `rest-server`**;
+  handlers pass `SystemSpec` through, covered by the `types.go` struct change):
+  update the example payloads (drop `atTokens`, generous `maxBatchSize`) and the
+  field descriptions — `maxBatchSize` becomes "search ceiling (max concurrency)
+  for the optimal-concurrency search; 0 ⇒ 256", and the `atTokens` line is
+  removed.
+- `pkg/core/allocation_test.go`, `pkg/solver/solver_test.go`: drop `AtTokens`,
+  give a generous `MaxBatchSize` ceiling plus ITL/TTFT targets, and update
+  expected batch sizes / assertions.
+- `zeroLoadAllocation` (`allocation.go` ~265): keeps using override-or-
+  `perf.MaxBatchSize` for its cosmetic batch-size value (no traffic ⇒ nothing to
+  optimize). The field there now denotes the ceiling; acceptable for the
+  zero-load case.
+
+## Testing
+
+- `pkg/core/allocation_test.go` (white-box): zero perfParms with non-zero load
+  still returns nil; zero-load still returns a valid minimum allocation; add a
+  case where a non-override candidate with valid perfParms + generous ceiling +
+  SLO targets yields a feasible `M*` within `[1, ceiling]`; add an infeasible-SLO
+  case asserting `nil` (not a batch-size-1 allocation).
+- `pkg/solver/solver_test.go` (black-box): existing zero-perfParms-errors and
+  valid-perfParms-nil expectations preserved with the updated perf-data shape.
+- `go test ./...`, `go vet ./...`, `go build ./...` green; `gofmt` clean.
+
+## Downstream impact / follow-up (out of scope)
+
+`llm-inferno/optimizer` depends on `optimizer-light` **directly** (`v0.7.8`) and
+pulls `queue-analysis` only *indirectly* through it. The batch-size decision lives
+entirely in optimizer-light's `CreateAllocation`, which `optimizer` reuses — it
+has no linear-scaling code of its own. Therefore:
+
+- The behavior change **propagates automatically** once `optimizer` bumps its
+  `optimizer-light` dependency to the version carrying this work. No logic change
+  required in `optimizer`.
+- The only follow-up is mechanical: after we tag `optimizer-light`, bump the
+  `optimizer` require, and give any `optimizer`-side sample data the same
+  treatment (drop `atTokens`, set generous `MaxBatchSize` ceilings).
+
+Tracked as a separate workitem.
+
+## Out of scope (YAGNI)
+
+- An opt-in linear-vs-optimal toggle.
+- A dedicated per-server ceiling field (`perf.MaxBatchSize` is the hook).
+- Computing the ceiling from KV-cache limits.
+- Consuming `ConcurrencyResult` diagnostics (`MITL`/`MTPF`/`oracleCalls`) in the
+  allocation output.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0
-	github.com/llm-inferno/queue-analysis v0.7.0
+	github.com/llm-inferno/queue-analysis v0.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/llm-inferno/queue-analysis v0.7.0 h1:3HWUjYcoojBdsZPNaf9rYfkhp/LLKF/i+/Tl1EeAhdA=
-github.com/llm-inferno/queue-analysis v0.7.0/go.mod h1:18cK7006sgMuEci090V6kbCJVwQ7kf82UeRMcDr/cxQ=
+github.com/llm-inferno/queue-analysis v0.8.0 h1:P7B0MOKowkvzjkdyFbGemz/H5fJukqwgq3cX4dwJCoA=
+github.com/llm-inferno/queue-analysis v0.8.0/go.mod h1:18cK7006sgMuEci090V6kbCJVwQ7kf82UeRMcDr/cxQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -17,6 +17,10 @@ var SLOMargin = -float32(math.Log(1 - SLOPercentile))
 // default maximum number of tokens in a batch (passed to LLMQueueAnalyzer)
 const DefaultMaxNumTokens = 8192
 
+// default upper bound (search ceiling) for the optimal-concurrency search;
+// used when a (model,accelerator)'s perf.MaxBatchSize is 0/unset
+const DefaultConcurrencyCeiling = 256
+
 // accelerator transition penalty factor
 var AccelPenaltyFactor = float32(0.1)
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -65,8 +65,7 @@ type ModelAcceleratorPerfData struct {
 	Name         string    `json:"name"`         // model name
 	Acc          string    `json:"acc"`          // accelerator name
 	AccCount     int       `json:"accCount"`     // number of accelerator units used by model
-	MaxBatchSize int       `json:"maxBatchSize"` // max batch size based on average number of tokens per request
-	AtTokens     int       `json:"atTokens"`     // average number of tokens per request assumed in max batch size calculation
+	MaxBatchSize int       `json:"maxBatchSize"` // search ceiling (max concurrency) for the optimal-concurrency search; 0 => DefaultConcurrencyCeiling (256)
 	PerfParms    PerfParms `json:"perfParms"`    // parameters for estimating decode and prefill times
 }
 

--- a/pkg/core/allocation.go
+++ b/pkg/core/allocation.go
@@ -81,33 +81,66 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return nil
 	}
 
-	// calculate max batch size (N) based on average request length (K)
+	// average request output length
 	K := load.AvgOutTokens
-
-	// use maxBatchSize from configured value or scaled performance data
-	var N int
-	if server.maxBatchSize > 0 {
-		N = server.maxBatchSize
-	} else {
-		N = max(perf.MaxBatchSize*perf.AtTokens/K, 1)
-	}
 	maxQueue := server.maxQueueSize
 
-	// create queue analyzer
+	serviceParms := &analyzer.ServiceParms{
+		Alpha: perf.PerfParms.Alpha,
+		Beta:  perf.PerfParms.Beta,
+		Gamma: perf.PerfParms.Gamma,
+	}
+	requestData := &analyzer.RequestSize{
+		AvgInputTokens:  float32(load.AvgInTokens),
+		AvgOutputTokens: float32(K),
+	}
+	targetPerf := &analyzer.TargetPerf{
+		TargetTTFT: target.TTFT,
+		TargetITL:  target.ITL,
+		TargetTPS:  target.TPS,
+	}
+
+	// determine max batch size (concurrency) N
+	var N int
+	if server.maxBatchSize > 0 {
+		// explicit override: use as-is, skip the search
+		N = server.maxBatchSize
+	} else {
+		// primary path: let the queue analyzer find the optimal concurrency
+		// (smallest max batch size reaching near-peak throughput under the SLO).
+		// perf.MaxBatchSize is the search ceiling; 0 => default ceiling.
+		ceiling := perf.MaxBatchSize
+		if ceiling <= 0 {
+			ceiling = config.DefaultConcurrencyCeiling
+		}
+		searchAnalyzer, err := analyzer.NewLLMQueueAnalyzer(&analyzer.Configuration{
+			MaxBatchSize: ceiling,
+			MaxNumTokens: config.DefaultMaxNumTokens,
+			MaxQueueSize: maxQueue,
+			ServiceParms: serviceParms,
+		}, requestData)
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+		res, err := searchAnalyzer.OptimalConcurrency(targetPerf)
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+		if res == nil || !res.Feasible {
+			// SLO unachievable within [1, ceiling]; skip this candidate.
+			return nil
+		}
+		N = res.Concurrency
+	}
+
+	// create queue analyzer at the chosen concurrency N
 	qConfig := &analyzer.Configuration{
 		MaxBatchSize: N,
 		MaxNumTokens: config.DefaultMaxNumTokens,
 		MaxQueueSize: maxQueue,
-		ServiceParms: &analyzer.ServiceParms{
-			Alpha: perf.PerfParms.Alpha,
-			Beta:  perf.PerfParms.Beta,
-			Gamma: perf.PerfParms.Gamma,
-		},
-	}
-
-	requestData := &analyzer.RequestSize{
-		AvgInputTokens:  float32(load.AvgInTokens),
-		AvgOutputTokens: float32(K),
+		ServiceParms: serviceParms,
 	}
 
 	queueAnalyzer, err := analyzer.NewLLMQueueAnalyzer(qConfig, requestData)
@@ -116,19 +149,9 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 		return nil
 	}
 
-	// TODO: do we need this?
-	// waitTimeLimit := target.TTFT / config.SLOMargin // distribution of waiting time assumed exponential
-
-	targetPerf := &analyzer.TargetPerf{
-		TargetTTFT: target.TTFT,
-		TargetITL:  target.ITL,
-		TargetTPS:  target.TPS,
-	}
-
 	// determine max rates to satisfy targets
 	_, metrics, _, err := queueAnalyzer.Size(targetPerf)
 	if err != nil {
-		// fmt.Println(err)
 		return nil
 	}
 	rateStar := metrics.Throughput

--- a/pkg/core/allocation_test.go
+++ b/pkg/core/allocation_test.go
@@ -6,11 +6,8 @@ import (
 	"github.com/llm-inferno/optimizer-light/pkg/config"
 )
 
-// newTestSystem builds the minimal System for allocation tests:
-// one accelerator (H100), one model (m1) with given perfParms,
-// one service class (Premium) with ITL/TTFT targets for m1,
-// one server (s1) with the given load.
-func newTestSystem(perfParms config.PerfParms, arrivalRate float32, minReplicas int) {
+// newTestSystemWithTargets is newTestSystem with explicit ITL/TTFT SLO targets.
+func newTestSystemWithTargets(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32, minReplicas int, sloITL, sloTTFT float32) {
 	sys := NewSystem()
 	TheSystem = sys
 
@@ -24,14 +21,14 @@ func newTestSystem(perfParms config.PerfParms, arrivalRate float32, minReplicas 
 	})
 	sys.SetModelsFromSpec(&config.ModelData{
 		PerfData: []config.ModelAcceleratorPerfData{
-			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: 16, AtTokens: 512,
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize,
 				PerfParms: perfParms},
 		},
 	})
 	sys.SetServiceClassesFromSpec(&config.ServiceClassData{
 		Spec: []config.ServiceClassSpec{
 			{Name: "Premium", Priority: 1, ModelTargets: []config.ModelTarget{
-				{Model: "m1", SLO_ITL: 100, SLO_TTFT: 2000},
+				{Model: "m1", SLO_ITL: sloITL, SLO_TTFT: sloTTFT},
 			}},
 		},
 	})
@@ -51,9 +48,17 @@ func newTestSystem(perfParms config.PerfParms, arrivalRate float32, minReplicas 
 	})
 }
 
+// newTestSystem builds the minimal System for allocation tests:
+// one accelerator (H100), one model (m1) with given perfParms,
+// one service class (Premium) with ITL/TTFT targets for m1,
+// one server (s1) with the given load.
+func newTestSystem(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32, minReplicas int) {
+	newTestSystemWithTargets(perfParms, maxBatchSize, arrivalRate, minReplicas, 100, 2000)
+}
+
 // Zero perfParms + non-zero load: CreateAllocation must return nil (guard fires).
 func TestCreateAllocation_ZeroPerfParms_NonZeroLoad_ReturnsNil(t *testing.T) {
-	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60, 1)
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60, 1)
 	alloc := CreateAllocation("s1", "H100")
 	if alloc != nil {
 		t.Errorf("expected nil allocation for zero perfParms with non-zero load, got %v", alloc)
@@ -63,7 +68,7 @@ func TestCreateAllocation_ZeroPerfParms_NonZeroLoad_ReturnsNil(t *testing.T) {
 // Zero perfParms + zero load: CreateAllocation must return non-nil (zeroLoadAllocation path,
 // perfParms not needed).
 func TestCreateAllocation_ZeroPerfParms_ZeroLoad_ReturnsNonNil(t *testing.T) {
-	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 0, 0)
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 0, 0)
 	alloc := CreateAllocation("s1", "H100")
 	if alloc == nil {
 		t.Error("expected non-nil allocation for zero load even with zero perfParms")
@@ -73,12 +78,61 @@ func TestCreateAllocation_ZeroPerfParms_ZeroLoad_ReturnsNonNil(t *testing.T) {
 // Zero perfParms + zero load + minReplicas > 0: zeroLoadAllocation must not produce +Inf
 // MaxArrvRatePerReplica (division-by-zero when maxServTime == 0).
 func TestCreateAllocation_ZeroPerfParms_ZeroLoad_NonZeroMinReplicas_NoInf(t *testing.T) {
-	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 0, 2)
+	newTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 0, 2)
 	alloc := CreateAllocation("s1", "H100")
 	if alloc == nil {
 		t.Fatal("expected non-nil allocation for zero load with minReplicas=2")
 	}
 	if alloc.MaxArrvRatePerReplica() != 0 {
 		t.Errorf("expected MaxArrvRatePerReplica=0 for zero perfParms, got %v", alloc.MaxArrvRatePerReplica())
+	}
+}
+
+// No benchmark (perf.MaxBatchSize == 0) + valid perfParms + lenient SLOs:
+// the analyzer's optimal-concurrency search must pick a batch size > 1.
+// The OLD linear formula computed N = max(0*AtTokens/K, 1) = 1, so this
+// asserts the new search path is in effect.
+func TestCreateAllocation_NoBenchmark_UsesSearchedConcurrency(t *testing.T) {
+	newTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 0, 60, 1)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc == nil {
+		t.Fatal("expected a feasible allocation with valid perfParms and lenient SLOs")
+	}
+	if alloc.MaxBatchSize() <= 1 {
+		t.Errorf("expected searched concurrency > 1, got %d", alloc.MaxBatchSize())
+	}
+	if alloc.MaxBatchSize() > config.DefaultConcurrencyCeiling {
+		t.Errorf("batch size %d exceeds search ceiling %d", alloc.MaxBatchSize(), config.DefaultConcurrencyCeiling)
+	}
+	if alloc.NumReplicas() < 1 {
+		t.Errorf("expected at least 1 replica, got %d", alloc.NumReplicas())
+	}
+}
+
+// Infeasible SLO (ITL target below what any batch size can achieve):
+// CreateAllocation must return nil (skip), never an allocation pinned to
+// the search's MMin=1 fallback.
+func TestCreateAllocation_InfeasibleSLO_ReturnsNil(t *testing.T) {
+	newTestSystemWithTargets(config.PerfParms{Alpha: 50, Beta: 1, Gamma: 0.1}, 256, 60, 1,
+		0.001 /*SLO_ITL*/, 0.001 /*SLO_TTFT*/)
+	alloc := CreateAllocation("s1", "H100")
+	if alloc != nil {
+		t.Errorf("expected nil for an unachievable SLO, got %v", alloc)
+	}
+}
+
+// Explicit server.maxBatchSize override: CreateAllocation must use it verbatim
+// and skip the optimal-concurrency search (result is the override, not a
+// searched value bounded by the perf ceiling).
+func TestCreateAllocation_Override_UsesGivenBatchSize(t *testing.T) {
+	newTestSystemWithTargets(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 256, 60, 1, 100, 2000)
+	const override = 7
+	GetServer("s1").maxBatchSize = override // in-package access; override the server's max batch size
+	alloc := CreateAllocation("s1", "H100")
+	if alloc == nil {
+		t.Fatal("expected a feasible allocation with an explicit override")
+	}
+	if alloc.MaxBatchSize() != override {
+		t.Errorf("expected batch size to equal override %d, got %d", override, alloc.MaxBatchSize())
 	}
 }

--- a/pkg/solver/solver_test.go
+++ b/pkg/solver/solver_test.go
@@ -10,7 +10,7 @@ import (
 
 // newSolverTestSystem builds a system identical to Task 1's newTestSystem,
 // but exposed here since solver_test is an external test package.
-func newSolverTestSystem(perfParms config.PerfParms, arrivalRate float32) {
+func newSolverTestSystem(perfParms config.PerfParms, maxBatchSize int, arrivalRate float32) {
 	sys := core.NewSystem()
 	core.TheSystem = sys
 
@@ -24,7 +24,7 @@ func newSolverTestSystem(perfParms config.PerfParms, arrivalRate float32) {
 	})
 	sys.SetModelsFromSpec(&config.ModelData{
 		PerfData: []config.ModelAcceleratorPerfData{
-			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: 16, AtTokens: 512,
+			{Name: "m1", Acc: "H100", AccCount: 1, MaxBatchSize: maxBatchSize,
 				PerfParms: perfParms},
 		},
 	})
@@ -55,7 +55,7 @@ func newSolverTestSystem(perfParms config.PerfParms, arrivalRate float32) {
 // When a server has no valid allocations (zero perfParms + non-zero load),
 // Solve() must return a non-nil error naming the unresolved server.
 func TestSolve_ZeroPerfParms_ReturnsError(t *testing.T) {
-	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60)
+	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60)
 	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: true})
 	err := s.Solve()
 	if err == nil {
@@ -65,7 +65,7 @@ func TestSolve_ZeroPerfParms_ReturnsError(t *testing.T) {
 
 // When a server has valid perfParms and load, Solve() must return nil (success).
 func TestSolve_ValidPerfParms_ReturnsNil(t *testing.T) {
-	newSolverTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 60)
+	newSolverTestSystem(config.PerfParms{Alpha: 1.5, Beta: 0.002, Gamma: 0.0001}, 256, 60)
 	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: true})
 	err := s.Solve()
 	if err != nil {
@@ -76,7 +76,7 @@ func TestSolve_ValidPerfParms_ReturnsNil(t *testing.T) {
 // When a server has no valid allocations and the greedy solver is used,
 // Solve() must also return a non-nil error naming the unresolved server.
 func TestSolveGreedy_ZeroPerfParms_ReturnsError(t *testing.T) {
-	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 60)
+	newSolverTestSystem(config.PerfParms{Alpha: 0, Beta: 0, Gamma: 0}, 256, 60)
 	s := solver.NewSolver(&config.OptimizerSpec{Unlimited: false})
 	err := s.Solve()
 	if err == nil {

--- a/rest-server/README.md
+++ b/rest-server/README.md
@@ -77,8 +77,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
                 "name": "granite_13b",
                 "acc": "A100",
                 "accCount": 1,
-                "maxBatchSize": 64,
-                "atTokens": 512,
+                "maxBatchSize": 256,
                 "perfParms": {
                     "alpha": 20.58,
                     "beta": 0.041,
@@ -89,8 +88,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
                 "name": "granite_13b",
                 "acc": "G2",
                 "accCount": 1,
-                "maxBatchSize": 76,
-                "atTokens": 512,
+                "maxBatchSize": 256,
                 "perfParms": {
                     "alpha": 17.15,
                     "beta": 0.034,
@@ -101,8 +99,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
                 "name": "llama_70b",
                 "acc": "G2",
                 "accCount": 4,
-                "maxBatchSize": 12,
-                "atTokens": 512,
+                "maxBatchSize": 256,
                 "perfParms": {
                     "alpha": 22.84,
                     "beta": 0.589,
@@ -116,8 +113,7 @@ The following data is needed by the Optimizer (Declarations described [types](..
     Performance data includes
 
    - `accCount`: number of accelerator (cards)
-   - `maxBatchSize`: maximum batch size to use, beyond which performance deteriorates
-   - `atTokens`: average number of tokens used when determining the `maxBatchSize`
+   - `maxBatchSize`: search ceiling (max concurrency) for the optimal-concurrency search that sizes each server; `0` uses the default ceiling (256). An explicit per-server `maxBatchSize` override (in server data) bypasses the search.
    - `perfParms`: performance parameters `alpha`, `beta`, and `gamma` (in msec) of the linear approximation of iteration time as a function of computed tokens and transferred tokens per batch (n), *iterationTime = alpha + beta . computedTokens + gamma . transferredTokens*
 
 1. **Service class data**: For all service classes, the specification, such as name, priority, and SLO targets for a service class. An example follows.


### PR DESCRIPTION
Closes #13.

Replaces the Optimizer's linear-in-tokens max-batch-size heuristic with the queue analyzer's **optimal-concurrency search** (queue-analysis PR #19, released as **v0.8.0**). For each (server, accelerator) candidate, `CreateAllocation` now asks the analyzer for the minimum concurrency `M*` that reaches near-peak throughput under the SLO, instead of scaling a benchmarked `maxBatchSize` by token count.

## What changed
- **`pkg/core/allocation.go`** — when `server.maxBatchSize` is set it's used verbatim (override, unchanged); otherwise build a search analyzer at a ceiling (= `perf.MaxBatchSize`, or `config.DefaultConcurrencyCeiling=256` if unset), call `OptimalConcurrency(targetPerf)`, and use `res.Concurrency` as the batch size. Infeasible SLO (`!res.Feasible`) ⇒ skip the candidate. The all-zero-perfParms guard and the downstream `Size()`/`Analyze()` flow are unchanged.
- **`pkg/config`** — add `DefaultConcurrencyCeiling = 256`; re-document `perf.MaxBatchSize` as the search ceiling; **retire `perf.AtTokens`**.
- **`demos/generators`** — emit a generous ceiling instead of the benchmarked matrix; drop `atTokens`.
- **`rest-server/README.md`** — docs only (payloads + field descriptions); no handler changes.
- **`go.mod`** — depend on tagged `queue-analysis v0.8.0`.
- **`sample-data` submodule** — bumped to `v0.8.0` (llm-inferno/sample-data#1): `atTokens` dropped, generous `maxBatchSize` ceilings.
- **Tests** — `pkg/core` covers the searched-concurrency path, the infeasible-SLO skip, and the override branch; `pkg/solver` exercises the search end-to-end. `go build/vet/test` and `gofmt` all green.

## Pre-merge requirements — ✅ resolved
1. ~~Swap the interim `replace => ../queue-analysis` for a tagged `require`.~~ **Done** — queue-analysis tagged `v0.8.0`; `go.mod` requires it; the `replace` is removed. Builds without any local sibling checkout.
2. ~~Merge the sample-data submodule PR and re-point the submodule.~~ **Done** — submodule now tracks `v0.8.0` (the squash-merged release commit).

## Follow-ups (out of scope)
- `llm-inferno/optimizer` inherits this automatically once it bumps its `optimizer-light` dependency (queue-analysis is indirect there) — mechanical bump + sample-data cleanup only.
- `zeroLoadAllocation` still uses `perf.MaxBatchSize` (now a ceiling) as a cosmetic batch size in the zero-traffic case — harmless, but a candidate for a later tidy (size idle batch to 1 or document).

Design & plan: `docs/superpowers/specs/2026-06-15-optimal-concurrency-batch-size-design.md`, `docs/superpowers/plans/2026-06-15-optimal-concurrency-batch-size.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)